### PR TITLE
feat: Get rid of Calico

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: 'Test Terraform on Hetzner'
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]    
 
 jobs:
   deploy-terraform:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ provider "kubernetes" {
   
   # For a single-master cluster, this will be an IPv6 URL. For IPv4, this can
   # also be used
-  # host = "https://${module.simple_cluster.master[0].ipv4_address}:6443"
+  # host = "https://${module.k8s.masters[0].ipv4_address}:6443"
 
   client_certificate     = module.k8s.client_certificate_data
   client_key             = module.k8s.client_key_data

--- a/README.md
+++ b/README.md
@@ -113,8 +113,11 @@ TLS certificate credentials form the output can be used to chain other Terraform
 ```hcl
 
 provider "kubernetes" {
-  host = module.k8s.apiserver_url_v6
-  # Or host = module.k8s.apiserver_url_v4 if you are on WSL2 :/
+  host = module.k8s.apiserver_url
+  
+  # For a single-master cluster, this will be an IPv6 URL. For IPv4, this can
+  # also be used
+  # host = "https://${module.simple_cluster.master[0].ipv4_address}:6443"
 
   client_certificate     = module.k8s.client_certificate_data
   client_key             = module.k8s.client_key_data

--- a/README.md
+++ b/README.md
@@ -6,25 +6,13 @@ Create a Kubernetes cluster on the [Hetzner cloud](https://registry.terraform.io
 
 - Single or multiple control plane nodes (in [HA configuration with stacked `etcd`](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/high-availability/))
 - containerd for CRI
-- [Cilium](https://cilium.io/) for CNI
+- IPv6 control plane communication
+- A [custom "network plugin"](./templates/cni.json.tpl), because all major network plugins are broken in various ways for dual-stack.
   - pods are allocated a private IPv4 address and a public IPv6 from the /64 subnet that Hetzner gives to every node. No masquerading needed for outbound IPv6 traffic!
   - Dual-stack and IPv6-only `Service`s get a private (ULA) IPv6 address
-  - Wireguard for pod-to-pod traffic encryption (Hetzner [private networks are [not encrypted](https://docs.hetzner.com/cloud/networks/faq/#is-traffic-inside-hetzner-cloud-networks-encrypted))
+  - A full-mesh static overlay network using Wireguard (pod-to-pod traffic is encrypted)  
 - deploys the [Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager) so `LoadBalancer` services provision Hetzner load balancers and deleted nodes are cleaned up.
 - deploys the [Container Storage Interface](https://github.com/hetznercloud/csi-driver) for dynamic provisioning of volumes
-
-## Some important notes
-
-While this module tries to follow Kuberentes best practices, exercise caution before using it in production, as it is not particularly hardened.
-
-- As pods get a public IPv6 address, the ports they bind are directly exposed to the public internet. If this is not desired, appropriate [Cilium network policy](https://docs.cilium.io/en/v1.10.0-rc1/policy/) or filtered at the edge through Hetzner firewall.
-- In a similar fashion, control plane services that use host networking, such as etcd, kubelet and api-server bind on a public IP. This is not a problem per se since these components all use mTLS for communication, they can be locked down through [Cilium Host Policies](https://docs.cilium.io/en/v1.10.0-rc1/policy/language/#host-policies) or at edge.
-- kubelet serving certificates are self-signed. This can be an issue for metrics-server. See [here](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs) for some workarounds.
-- No cluster autoscaler support as the networking configuration is done in Terraform.
-- Limited day-2 operations. The following are supported, but other changes will likely require the cluster to be recreated:
-   - Node replacement (with the exception of first master node)
-   - Vertical scaling of node (changing the server type)
-   - Horizontal scaling (changing node count) of both master and worker nodes 
 
 ## Getting Started
 
@@ -80,6 +68,44 @@ This module can create a multi-master setup with a highly available control plan
 - A Hetzner load balancer in front of the control-plane nodes (see [example](./examples/ha_load_balancer.tf))
 - External load balancer (or a DNS-based solution). Whatever is specified in `control_plane_endpoint` will be used as a API server endpoint and it is up to you to make sure request are routed to the master nodes  (see [example](./examples/ha_dns_name.tf))
 
+It is recommended to set up `control_plane_endpoint` (e.g. a DNS record) even if a single master node is used, as doing so will allow for additional master nodes to be added later. If this is not done, the
+cluster will have to be manually reconfigured (e.g [like this](https://blog.scottlowe.org/2019/08/12/converting-kubernetes-to-ha-control-plane/)) to use the new endpoint when new master nodes are added.
+
+### Removing/replacing master nodes
+
+A first step before removing a control plane node is to remove it from the `etcd` cluster.
+If the node is still operational, the easiest way to do it is with `kubeadm`. Otherwise, it will have to be done manually with `etcdctl`. This is very important! If not done, new nodes will not be able to join, even if the `etcd` cluster has quorum.
+
+```cmd
+kubeadm reset --force
+```
+
+You may also need to manually remove the node, as the Hetzner Cloud Controller that is responsible for deleting defunct nodes may have been running on this very node (should not be an issue if `kubectl drain` was done first)
+
+```
+kubectl delete node <node name>
+```
+
+First master node is special in that it is used by the provisioning process (e.g. to get the bootstrap tokens for other nodes). If the first node is deleted, another server must be specified, otherwise provisioning operations will fail.
+
+```hcl
+module "k8s" {
+  source  = "tibordp/dualstack-k8s/hcloud"
+ 
+  ...
+ 
+  kubeadm_host = "<ip address of another master node>"
+}
+```
+
+Afterwards, the node can be replaced as usual, e.g.
+
+```
+terraform taint module.k8s.module.master[0].hcloud_server.instance
+terraform apply
+```
+
+
 ## Chaining other Terraform modules
 
 TLS certificate credentials form the output can be used to chain other Terraform modules, such as the [Kubernetes provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs):
@@ -94,6 +120,20 @@ provider "kubernetes" {
   cluster_ca_certificate = module.k8s.certificate_authority_data
 }
 ```
+
+## Caveats
+
+Exercise caution before using this module in production, as it is not particularly hardened.
+
+- As pods get a public IPv6 address, the ports they bind are directly exposed to the public internet. This can be mitigated by attaching a Hetzner Cloud Firewall (which is a stateful firewall). Pod-to-pod communication is done through an encrypted tunnel (UDP port 51820), so other ingress IPv6 to pod subnets can safely be blocked at the edge without interfering with internal traffic.
+- In a similar fashion, control plane services that use host networking, such as etcd, kubelet and api-server bind on a public IP. This is not a problem per se since these components all use mTLS for communication
+- No `NetworkPolicy` support (if you can make it work, please let me know!)
+- kubelet serving certificates are self-signed. This can be an issue for metrics-server. See [here](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs) for some workarounds.
+- Some restrictions on day-2 operations. The following are supported seamlessly, but other changes will likely require the cluster to be recreated (or replaced node-by-node):
+   - Node replacement (see notes below for control plane nodes)
+   - Vertical scaling of node (changing the server type)
+   - Horizontal scaling (changing node count) of both master and worker nodes.
+- No cluster autoscaler support as the networking setup is statically performed in Terraform.
 
 ## Acknowledgements 
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Exercise caution before using this module in production, as it is not particular
    - Node replacement (see notes below for control plane nodes)
    - Vertical scaling of node (changing the server type)
    - Horizontal scaling (changing node count) of both master and worker nodes.
-- No cluster autoscaler support as the networking setup is statically performed in Terraform.
+- No cluster autoscaler support as the networking routing is statically rendered in Terraform.
 
 ## Acknowledgements 
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ TLS certificate credentials form the output can be used to chain other Terraform
 ```hcl
 
 provider "kubernetes" {
-  host = module.k8s.apiserver_url
+  host = module.k8s.apiserver_url_v6
+  # Or host = module.k8s.apiserver_url_v4 if you are on WSL2 :/
 
   client_certificate     = module.k8s.client_certificate_data
   client_key             = module.k8s.client_key_data

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -2,7 +2,7 @@ module "kubeconfig" {
   source     = "matti/resource/shell"
   depends_on = [null_resource.cluster_bootstrap]
 
-  trigger = module.master[0].id
+  trigger = null_resource.cluster_bootstrap.id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
@@ -14,7 +14,7 @@ module "certificate_authority_data" {
   source     = "matti/resource/shell"
   depends_on = [null_resource.cluster_bootstrap]
 
-  trigger = module.master[0].id
+  trigger = null_resource.cluster_bootstrap.id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path}  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
@@ -26,7 +26,7 @@ module "client_certificate_data" {
   source     = "matti/resource/shell"
   depends_on = [null_resource.cluster_bootstrap]
 
-  trigger = module.master[0].id
+  trigger = null_resource.cluster_bootstrap.id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path}  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
@@ -38,7 +38,7 @@ module "client_key_data" {
   source     = "matti/resource/shell"
   depends_on = [null_resource.cluster_bootstrap]
 
-  trigger = module.master[0].id
+  trigger = null_resource.cluster_bootstrap.id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path}  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -1,47 +1,47 @@
 module "kubeconfig" {
   source     = "matti/resource/shell"
-  depends_on = [null_resource.master_init]
+  depends_on = [null_resource.cluster_bootstrap]
 
   trigger = module.master[0].id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      root@${module.master[0].ipv4_address} 'cat /root/.kube/config'
+      root@${local.kubeadm_host} 'cat /root/.kube/config'
   EOT
 }
 
 module "certificate_authority_data" {
   source     = "matti/resource/shell"
-  depends_on = [null_resource.master_init]
+  depends_on = [null_resource.cluster_bootstrap]
 
   trigger = module.master[0].id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path}  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      root@${module.master[0].ipv4_address} 'kubectl config --kubeconfig /root/.kube/config view --flatten -o jsonpath='{.clusters[0].cluster.certificate-authority-data}''
+      root@${local.kubeadm_host} 'kubectl config --kubeconfig /root/.kube/config view --flatten -o jsonpath='{.clusters[0].cluster.certificate-authority-data}''
   EOT
 }
 
 module "client_certificate_data" {
   source     = "matti/resource/shell"
-  depends_on = [null_resource.master_init]
+  depends_on = [null_resource.cluster_bootstrap]
 
   trigger = module.master[0].id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path}  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      root@${module.master[0].ipv4_address} 'kubectl config --kubeconfig /root/.kube/config view --flatten -o jsonpath='{.users[0].user.client-certificate-data}''
+      root@${local.kubeadm_host} 'kubectl config --kubeconfig /root/.kube/config view --flatten -o jsonpath='{.users[0].user.client-certificate-data}''
   EOT
 }
 
 module "client_key_data" {
   source     = "matti/resource/shell"
-  depends_on = [null_resource.master_init]
+  depends_on = [null_resource.cluster_bootstrap]
 
   trigger = module.master[0].id
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path}  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      root@${module.master[0].ipv4_address} 'kubectl config --kubeconfig /root/.kube/config view --flatten -o jsonpath='{.users[0].user.client-key-data}''
+      root@${local.kubeadm_host} 'kubectl config --kubeconfig /root/.kube/config view --flatten -o jsonpath='{.users[0].user.client-key-data}''
   EOT
 }

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -1,11 +1,11 @@
 locals {
-  use_load_balancer = local.high_availability && (var.control_plane_lb_type != "" || var.control_plane_endpoint == "")
+  use_load_balancer = var.control_plane_lb_type != ""
 }
 
 resource "hcloud_load_balancer" "control_plane" {
   count              = local.use_load_balancer ? 1 : 0
   name               = "${var.name}-control-plane"
-  load_balancer_type = var.control_plane_lb_type != "" ? var.control_plane_lb_type : "lb11"
+  load_balancer_type = var.control_plane_lb_type
   location           = var.location
 }
 

--- a/master.tf
+++ b/master.tf
@@ -1,6 +1,7 @@
 locals {
-  control_plane_endpoint = var.control_plane_endpoint != "" ? var.control_plane_endpoint : (local.use_load_balancer ? "[${hcloud_load_balancer.control_plane[0].ipv6}]" : "[${module.master[0].ipv6_address}]")
-  kubeadm_host           = var.kubeadm_host != "" ? var.kubeadm_host : module.master[0].ipv4_address
+  control_plane_endpoint_v6 = var.control_plane_endpoint != "" ? var.control_plane_endpoint : (local.use_load_balancer ? "[${hcloud_load_balancer.control_plane[0].ipv6}]" : "[${module.master[0].ipv6_address}]")
+  control_plane_endpoint_v4 = var.control_plane_endpoint != "" ? var.control_plane_endpoint : (local.use_load_balancer ? "[${hcloud_load_balancer.control_plane[0].ipv4}]" : "[${module.master[0].ipv4_address}]")
+  kubeadm_host              = var.kubeadm_host != "" ? var.kubeadm_host : module.master[0].ipv4_address
 }
 
 module "master" {
@@ -28,7 +29,7 @@ data "template_file" "kubeadm" {
   template = file("${path.module}/templates/kubeadm.yaml.tpl")
   vars = {
     certificate_key        = random_id.certificate_key.hex
-    control_plane_endpoint = local.control_plane_endpoint
+    control_plane_endpoint = local.control_plane_endpoint_v6
     advertise_address      = module.master[0].ipv6_address
     service_cidr_ipv4      = var.service_cidr_ipv4
     service_cidr_ipv6      = var.service_cidr_ipv6

--- a/master.tf
+++ b/master.tf
@@ -1,6 +1,6 @@
 locals {
-  high_availability      = var.control_plane_endpoint != "" || var.master_count > 1 || var.control_plane_lb_type != ""
-  control_plane_endpoint = local.high_availability ? (var.control_plane_endpoint != "" ? var.control_plane_endpoint : hcloud_load_balancer.control_plane[0].ipv4) : ""
+  control_plane_endpoint = var.control_plane_endpoint != "" ? var.control_plane_endpoint : (local.use_load_balancer ? "[${hcloud_load_balancer.control_plane[0].ipv6}]" : module.master[0].ipv6_address)
+  kubeadm_host           = var.kubeadm_host != "" ? var.kubeadm_host : module.master[0].ipv4_address
 }
 
 module "master" {
@@ -20,37 +20,31 @@ module "master" {
   ssh_private_key_path = var.ssh_private_key_path
 }
 
-
-module "certificate_key" {
-  count      = local.high_availability ? 1 : 0
-  source     = "matti/resource/shell"
-  depends_on = [module.master]
-
-  trigger = module.master[0].id
-
-  command = <<EOT
-    ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      root@${module.master[0].ipv4_address} 'kubeadm certs certificate-key'
-  EOT
+resource "random_id" "certificate_key" {
+  byte_length = 32
 }
 
 data "template_file" "kubeadm" {
   template = file("${path.module}/templates/kubeadm.yaml.tpl")
   vars = {
-    ha_control_plane       = local.high_availability
-    certificate_key        = local.high_availability ? module.certificate_key[0].stdout : ""
-    control_plane_endpoint = local.high_availability ? local.control_plane_endpoint : ""
-    advertise_address      = module.master[0].ipv4_address
+    certificate_key        = random_id.certificate_key.hex
+    control_plane_endpoint = local.control_plane_endpoint
+    advertise_address      = module.master[0].ipv6_address
     service_cidr_ipv4      = var.service_cidr_ipv4
     service_cidr_ipv6      = var.service_cidr_ipv6
   }
 }
 
-resource "null_resource" "master_init" {
-  depends_on = [
-    module.certificate_key
-  ]
+data "template_file" "master_cni" {
+  count    = var.master_count
+  template = file("${path.module}/templates/cni.json.tpl")
+  vars = {
+    pod_subnet_v6 = module.master[count.index].pod_subnet_v6
+    pod_subnet_v4 = module.master[count.index].pod_subnet_v4
+  }
+}
 
+resource "null_resource" "cluster_bootstrap" {
   connection {
     host        = module.master[0].ipv4_address
     type        = "ssh"
@@ -65,6 +59,11 @@ resource "null_resource" "master_init" {
   }
 
   provisioner "file" {
+    content     = data.template_file.master_cni[0].rendered
+    destination = "/etc/cni/net.d/10-tibornet.conflist"
+  }
+
+  provisioner "file" {
     content     = data.template_file.kubeadm.rendered
     destination = "/root/cluster.yaml"
   }
@@ -72,27 +71,24 @@ resource "null_resource" "master_init" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /root/cluster-init.sh",
-      "HA_CONTROL_PLANE=${local.high_availability ? 1 : 0} /root/cluster-init.sh",
-    ]
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      <<EOT
-      kubectl patch node '${var.name}-master-0' \
-        -p '${jsonencode({ "spec" = module.master[0].pod_cidrs })}'
-      EOT
+      "/root/cluster-init.sh",
     ]
   }
 }
 
-resource "null_resource" "setup_cluster" {
+resource "null_resource" "master_join" {
+  count = var.master_count
+
   depends_on = [
-    null_resource.master_init
+    null_resource.cluster_bootstrap
   ]
 
+  triggers = {
+    instance_id = module.master[count.index].id
+  }
+
   connection {
-    host        = module.master[0].ipv4_address
+    host        = module.master[count.index].ipv4_address
     type        = "ssh"
     timeout     = "5m"
     user        = "root"
@@ -100,89 +96,32 @@ resource "null_resource" "setup_cluster" {
   }
 
   provisioner "file" {
-    source      = "${path.module}/scripts/cluster-setup.sh"
-    destination = "/root/cluster-setup.sh"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "chmod +x /root/cluster-setup.sh",
-      "HCLOUD_TOKEN='${var.hcloud_token}' /root/cluster-setup.sh",
-    ]
-  }
-}
-
-
-resource "null_resource" "master_join" {
-  count = local.high_availability ? var.master_count - 1 : 0
-
-  depends_on = [
-    null_resource.master_init
-  ]
-
-  triggers = {
-    instance_id  = module.master[count.index + 1].id
-    ipv4_address = module.master[count.index + 1].ipv4_address
+    content     = data.template_file.master_cni[count.index].rendered
+    destination = "/etc/cni/net.d/10-tibornet.conflist"
   }
 
   provisioner "local-exec" {
     command = <<EOT
       ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        root@${module.master[0].ipv4_address} \
+        root@${local.kubeadm_host} \
         'echo $(kubeadm token create --print-join-command --ttl=60m) \
-        --apiserver-advertise-address ${module.master[count.index + 1].ipv4_address} \
+        --apiserver-advertise-address ${module.master[count.index].ipv6_address} \
         --control-plane \
-        --certificate-key ${module.certificate_key[0].stdout} \
-        --skip-phases control-plane-join' | \
+        --certificate-key ${random_id.certificate_key.hex}' | \
       ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        root@${module.master[count.index + 1].ipv4_address}
+        root@${module.master[count.index].ipv4_address} 'tee /root/join-command.sh'
     EOT
   }
 
-  provisioner "remote-exec" {
-    connection {
-      host        = module.master[0].ipv4_address
-      type        = "ssh"
-      timeout     = "5m"
-      user        = "root"
-      private_key = file(var.ssh_private_key_path)
-    }
-
-    inline = [
-      <<EOT
-      kubectl patch node '${var.name}-master-${count.index + 1}' \
-        -p '${jsonencode({ "spec" = module.master[count.index + 1].pod_cidrs })}'
-      EOT
-    ]
+  provisioner "file" {
+    source      = "${path.module}/scripts/cluster-init.sh"
+    destination = "/root/cluster-init.sh"
   }
 
-  # We need CNI to be operational on the node before we can complete the join
   provisioner "remote-exec" {
-    connection {
-      host        = self.triggers.ipv4_address
-      type        = "ssh"
-      timeout     = "5m"
-      user        = "root"
-      private_key = file(var.ssh_private_key_path)
-    }
-
     inline = [
-      <<EOT
-      kubeadm join phase control-plane-join all \
-        --control-plane \
-        --apiserver-advertise-address ${module.master[count.index + 1].ipv4_address}
-      EOT
+      "chmod +x /root/cluster-init.sh",
+      "/root/cluster-init.sh",
     ]
-  }
-
-  # It is important to leave the etcd quorum before shutting down the control plane node,
-  # as it will not be done automatically. This deprovisioner can only use the default ssh key due to
-  # https://github.com/hashicorp/terraform/issues/23679
-  provisioner "local-exec" {
-    when    = destroy
-    command = <<EOT
-      ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        root@${self.triggers.ipv4_address} 'kubeadm reset --force --skip-phases cleanup-node'
-    EOT
   }
 }

--- a/master.tf
+++ b/master.tf
@@ -1,5 +1,5 @@
 locals {
-  control_plane_endpoint = var.control_plane_endpoint != "" ? var.control_plane_endpoint : (local.use_load_balancer ? "[${hcloud_load_balancer.control_plane[0].ipv6}]" : module.master[0].ipv6_address)
+  control_plane_endpoint = var.control_plane_endpoint != "" ? var.control_plane_endpoint : (local.use_load_balancer ? "[${hcloud_load_balancer.control_plane[0].ipv6}]" : "[${module.master[0].ipv6_address}]")
   kubeadm_host           = var.kubeadm_host != "" ? var.kubeadm_host : module.master[0].ipv4_address
 }
 

--- a/modules/kubernetes-node/main.tf
+++ b/modules/kubernetes-node/main.tf
@@ -8,8 +8,9 @@ terraform {
 }
 
 locals {
-  pod_subnet_v4 = cidrsubnet("10.0.0.0/8", 10, var.node_index + 1)
-  pod_subnet_v6 = cidrsubnet(hcloud_server.instance.ipv6_network, 16, 1)
+  pod_subnet_v4        = cidrsubnet("10.0.0.0/8", 10, var.node_index + 1)
+  pod_subnet_v6        = cidrsubnet(hcloud_server.instance.ipv6_network, 16, 1)
+  private_ipv4_address = cidrhost("10.0.0.0/8", var.node_index + 2)
 }
 
 resource "hcloud_server" "instance" {
@@ -31,14 +32,25 @@ resource "hcloud_server" "instance" {
   }
 
   provisioner "file" {
-    source      = "${path.module}/scripts/bootstrap.sh"
-    destination = "/root/bootstrap.sh"
+    source      = "${path.module}/scripts/prepare-node.sh"
+    destination = "/root/prepare-node.sh"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "chmod +x /root/bootstrap.sh",
-      "/root/bootstrap.sh",
+      "chmod +x /root/prepare-node.sh",
+      "/root/prepare-node.sh",
     ]
   }
+}
+
+module "wireguard_public_key" {
+  source = "matti/resource/shell"
+
+  trigger = hcloud_server.instance.id
+
+  command = <<EOT
+    ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+     root@${hcloud_server.instance.ipv4_address} 'cat /etc/wg_pub.key'
+  EOT
 }

--- a/modules/kubernetes-node/outputs.tf
+++ b/modules/kubernetes-node/outputs.tf
@@ -3,6 +3,11 @@ output "id" {
   value       = hcloud_server.instance.id
 }
 
+output "private_ipv4_address" {
+  description = "IPv4 address of the server"
+  value       = local.private_ipv4_address
+}
+
 output "ipv4_address" {
   description = "IPv4 address of the server"
   value       = hcloud_server.instance.ipv4_address
@@ -18,13 +23,17 @@ output "ipv6_network" {
   value       = hcloud_server.instance.ipv6_network
 }
 
-output "pod_cidrs" {
-  description = "Per-node pod CIDR configuration"
-  value = {
-    "podCIDR" = local.pod_subnet_v6
-    "podCIDRs" = [
-      local.pod_subnet_v6,
-      local.pod_subnet_v4
-    ]
-  }
+output "pod_subnet_v6" {
+  description = "IPv6 address of the server"
+  value       = local.pod_subnet_v6
+}
+
+output "pod_subnet_v4" {
+  description = "IPv6 network of the server"
+  value       = local.pod_subnet_v4
+}
+
+output "wireguard_public_key" {
+  description = "IPv6 network of the server"
+  value       = module.wireguard_public_key.stdout
 }

--- a/modules/kubernetes-node/scripts/prepare-node.sh
+++ b/modules/kubernetes-node/scripts/prepare-node.sh
@@ -21,13 +21,18 @@ sudo sysctl --system
 
 # Install CRI
 sudo apt-get update
+sudo apt-get upgrade -y
 sudo apt-get install -y \
   apt-transport-https \
   ca-certificates \
   curl \
   gnupg \
   lsb-release \
-  ipvsadm
+  ipvsadm \
+  wireguard
+
+wg genkey | sudo tee /etc/wg_priv.key | wg pubkey > /etc/wg_pub.key
+sudo chmod 600 /etc/wg_priv.key
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo \
@@ -57,4 +62,5 @@ cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/20-hcloud.conf
 Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
 EOF
 
+kubeadm config images pull
 sudo systemctl restart kubelet

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,9 +13,14 @@ output "load_balancer" {
   value       = local.use_load_balancer ? hcloud_load_balancer.control_plane[0] : null
 }
 
-output "apiserver_url" {
+output "apiserver_url_v4" {
   description = "URL for the API server"
-  value       = yamldecode(module.kubeconfig.stdout).clusters[0].cluster.server
+  value       = "https://${local.control_plane_endpoint_v4}:6443"
+}
+
+output "apiserver_url_v6" {
+  description = "URL for the API server"
+  value       = "https://${local.control_plane_endpoint_v6}:6443"
 }
 
 output "client_certificate_data" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,14 +13,9 @@ output "load_balancer" {
   value       = local.use_load_balancer ? hcloud_load_balancer.control_plane[0] : null
 }
 
-output "apiserver_url_v4" {
+output "apiserver_url" {
   description = "URL for the API server"
-  value       = "https://${local.control_plane_endpoint_v4}:6443"
-}
-
-output "apiserver_url_v6" {
-  description = "URL for the API server"
-  value       = "https://${local.control_plane_endpoint_v6}:6443"
+  value       = "https://${local.control_plane_endpoint}:6443"
 }
 
 output "client_certificate_data" {

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ "$HA_CONTROL_PLANE" == "1" ]]
-then
-  sudo kubeadm init --config cluster.yaml --upload-certs
+if [[ -f "$HOME/.kube/config" ]]; then
+    # This script runs also on the node that bootstrapped the cluster
+    # so that it can be replaced later.
+    echo "Node already provisioned, skipping..."
+    exit 0
+fi
+
+if [[ -f "join-command.sh" ]]; then
+  chmod +x join-command.sh
+  sudo ./join-command.sh
 else
-  sudo kubeadm init --config cluster.yaml
+  sudo kubeadm init --config cluster.yaml --upload-certs
 fi
 
 mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config

--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# Install CNI
-curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
-sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
-
-cilium install --version v1.10.0-rc1 \
-  --ipam kubernetes \
-  --config enable-wireguard=true,enable-l7-proxy=false,enable-ipv6=true,enable-ipv6-masquerade=false,egress-masquerade-interfaces=eth0,ipam=kubernetes
+# Install ip-masq-agent
+kubectl apply -f ip-masq-agent.yaml
 
 # Install cloud provider
 kubectl -n kube-system create secret generic hcloud --from-literal=token="$HCLOUD_TOKEN"

--- a/setup.tf
+++ b/setup.tf
@@ -1,0 +1,32 @@
+resource "null_resource" "setup_cluster" {
+  depends_on = [
+    null_resource.cluster_bootstrap
+  ]
+
+  connection {
+    host        = local.kubeadm_host
+    type        = "ssh"
+    timeout     = "5m"
+    user        = "root"
+    private_key = file(var.ssh_private_key_path)
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/ip_masq_agent.yaml.tpl", {
+      non_masquerade_ranges = ["10.0.0.0/8", var.service_cidr_ipv4]
+    })
+    destination = "/root/ip-masq-agent.yaml"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/cluster-setup.sh"
+    destination = "/root/cluster-setup.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /root/cluster-setup.sh",
+      "HCLOUD_TOKEN='${var.hcloud_token}' /root/cluster-setup.sh",
+    ]
+  }
+}

--- a/templates/cni.json.tpl
+++ b/templates/cni.json.tpl
@@ -1,0 +1,41 @@
+{
+  "cniVersion": "0.3.1",
+  "name": "tibornet",
+  "plugins": [
+    {
+      "type": "ptp",
+      "ipMasq": false,
+      "ipam": {
+        "type": "host-local",
+        "dataDir": "/run/cni-ipam-state",
+        "routes": [
+          {
+            "dst": "::/0"
+          },
+          {
+            "dst": "0.0.0.0/0"
+          }          
+        ],
+        "ranges": [
+          [
+            {
+              "subnet": "${pod_subnet_v6}"
+            }
+          ],
+          [          
+            {
+              "subnet": "${pod_subnet_v4}"
+            }
+          ]
+        ]
+      },
+      "mtu": 1500
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    }
+  ]
+}

--- a/templates/ip_masq_agent.yaml.tpl
+++ b/templates/ip_masq_agent.yaml.tpl
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ip-masq-agent
+  namespace: kube-system
+data:
+  config: |
+    nonMasqueradeCIDRs:
+%{ for range in non_masquerade_ranges ~}
+    - "${range}"
+%{ endfor ~}
+    resyncInterval: 60s
+    masqLinkLocal: false
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ip-masq-agent
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: ip-masq-agent
+  template:
+    metadata:
+      labels:
+        k8s-app: ip-masq-agent
+    spec:
+      hostNetwork: true
+      containers:
+      - name: ip-masq-agent
+        image: k8s.gcr.io/networking/ip-masq-agent-amd64:v2.6.0
+        args:
+            - --masq-chain=IP-MASQ
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: config
+            mountPath: /etc/config
+      volumes:
+        - name: config
+          configMap:
+            name: ip-masq-agent
+            optional: true
+            items:
+              - key: config
+                path: ip-masq-agent
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"

--- a/templates/kubeadm.yaml.tpl
+++ b/templates/kubeadm.yaml.tpl
@@ -4,9 +4,7 @@ cgroupDriver: systemd
 ---
 kind: InitConfiguration
 apiVersion: kubeadm.k8s.io/v1beta2
-%{ if ha_control_plane }
 certificateKey: "${certificate_key}"
-%{ endif }
 localAPIEndpoint:
   advertiseAddress: "${advertise_address}"
   bindPort: 6443
@@ -16,8 +14,15 @@ apiVersion: kubeadm.k8s.io/v1beta2
 kubernetesVersion: v1.21.0
 featureGates:
   IPv6DualStack: true
+controllerManager:
+  extraArgs:
+    node-cidr-mask-size-ipv4: "24"
+    node-cidr-mask-size-ipv6: "120"
 networking:
-  serviceSubnet: ${service_cidr_ipv4},${service_cidr_ipv6}
-%{ if ha_control_plane }
+  serviceSubnet: ${service_cidr_ipv6},${service_cidr_ipv4}
 controlPlaneEndpoint: "${control_plane_endpoint}:6443"
-%{ endif }
+---
+kind: KubeProxyConfiguration
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+# IPVS unfortunately breaks Hetzner LoadBalancer healthchecks
+# mode: ipvs

--- a/templates/kubeadm.yaml.tpl
+++ b/templates/kubeadm.yaml.tpl
@@ -14,6 +14,11 @@ apiVersion: kubeadm.k8s.io/v1beta2
 kubernetesVersion: v1.21.0
 featureGates:
   IPv6DualStack: true
+apiServer:
+  certSANs:
+%{ for san in apiserverCertSans ~}
+  - "${san}"
+%{ endfor ~}
 controllerManager:
   extraArgs:
     node-cidr-mask-size-ipv4: "24"

--- a/templates/wireguard.yaml.tpl
+++ b/templates/wireguard.yaml.tpl
@@ -1,0 +1,29 @@
+network:
+    version: 2
+    tunnels:
+      wg0:
+        mode: wireguard
+        addresses:
+%{ for prefix in addresses ~}            
+          - "${prefix}"
+%{ endfor ~}        
+        routes:
+%{ for peer in peers ~}
+%{ for route in peer.routes ~}
+          - to: "${route}"
+            scope: link                 
+%{ endfor ~}
+%{ endfor ~}
+        peers:
+%{ for peer in peers ~}
+          - keys:
+              public: "${peer.public_key}"
+            allowed-ips:
+%{ for prefix in peer.allowed_ips ~}            
+              - "${prefix}"
+%{ endfor ~}
+            endpoint: "${peer.endpoint}:51820"
+%{ endfor ~}
+        port: 51820
+        keys:
+          private: "__PRIVATE_KEY__"

--- a/test/main.tf
+++ b/test/main.tf
@@ -54,8 +54,11 @@ module "ha_cluster" {
 
 provider "kubernetes" {
   alias = "simple_cluster"
-  # GitHub Actions does not have IPv6 connectivity. Shame.
-  host = module.simple_cluster.apiserver_url_v4
+  # GitHub Actions does not have IPv6 connectivity. Insecure needed since
+  # the API server does not have its IPv4 address in certificate SANs.
+  # Shaaaame!
+  insecure = true
+  host     = module.simple_cluster.apiserver_url_v4
 
   client_certificate     = module.simple_cluster.client_certificate_data
   client_key             = module.simple_cluster.client_key_data
@@ -64,8 +67,11 @@ provider "kubernetes" {
 
 provider "kubernetes" {
   alias = "ha_cluster"
-  # GitHub Actions does not have IPv6 connectivity. Shame.
-  host = module.ha_cluster.apiserver_url_v4
+  # GitHub Actions does not have IPv6 connectivity. Insecure needed since
+  # the API server does not have its IPv4 address in certificate SANs
+  # Shaaaame!
+  insecure = true
+  host     = module.ha_cluster.apiserver_url_v4
 
   client_certificate     = module.ha_cluster.client_certificate_data
   client_key             = module.ha_cluster.client_key_data

--- a/test/main.tf
+++ b/test/main.tf
@@ -46,7 +46,7 @@ module "ha_cluster" {
   master_server_type = "cx21"
   worker_server_type = "cx21"
 
-  load_balancer_type = "lb11"
+  control_plane_lb_type = "lb11"
 
   worker_count = 1
   master_count = 2

--- a/test/main.tf
+++ b/test/main.tf
@@ -54,11 +54,8 @@ module "ha_cluster" {
 
 provider "kubernetes" {
   alias = "simple_cluster"
-  # GitHub Actions does not have IPv6 connectivity. Insecure needed since
-  # the API server does not have its IPv4 address in certificate SANs.
-  # Shaaaame!
-  insecure = true
-  host     = module.simple_cluster.apiserver_url_v4
+  # GitHub Actions does not have IPv6 connectivity, so we need to use IPv4 :/
+  host = "https://${module.simple_cluster.master[0].ipv4_address}:6443"
 
   client_certificate     = module.simple_cluster.client_certificate_data
   client_key             = module.simple_cluster.client_key_data
@@ -67,11 +64,8 @@ provider "kubernetes" {
 
 provider "kubernetes" {
   alias = "ha_cluster"
-  # GitHub Actions does not have IPv6 connectivity. Insecure needed since
-  # the API server does not have its IPv4 address in certificate SANs
-  # Shaaaame!
-  insecure = true
-  host     = module.ha_cluster.apiserver_url_v4
+  # GitHub Actions does not have IPv6 connectivity, so we need to use IPv4 :/
+  host = "https://${module.simple_cluster.load_balancer.ipv4}:6443"
 
   client_certificate     = module.ha_cluster.client_certificate_data
   client_key             = module.ha_cluster.client_key_data

--- a/test/main.tf
+++ b/test/main.tf
@@ -46,6 +46,8 @@ module "ha_cluster" {
   master_server_type = "cx21"
   worker_server_type = "cx21"
 
+  load_balancer_type = "lb11"
+
   worker_count = 1
   master_count = 2
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -55,7 +55,7 @@ module "ha_cluster" {
 provider "kubernetes" {
   alias = "simple_cluster"
   # GitHub Actions does not have IPv6 connectivity, so we need to use IPv4 :/
-  host = "https://${module.simple_cluster.master[0].ipv4_address}:6443"
+  host = "https://${module.simple_cluster.masters[0].ipv4_address}:6443"
 
   client_certificate     = module.simple_cluster.client_certificate_data
   client_key             = module.simple_cluster.client_key_data
@@ -65,7 +65,7 @@ provider "kubernetes" {
 provider "kubernetes" {
   alias = "ha_cluster"
   # GitHub Actions does not have IPv6 connectivity, so we need to use IPv4 :/
-  host = "https://${module.simple_cluster.load_balancer.ipv4}:6443"
+  host = "https://${module.ha_cluster.load_balancer.ipv4}:6443"
 
   client_certificate     = module.ha_cluster.client_certificate_data
   client_key             = module.ha_cluster.client_key_data

--- a/test/main.tf
+++ b/test/main.tf
@@ -54,7 +54,8 @@ module "ha_cluster" {
 
 provider "kubernetes" {
   alias = "simple_cluster"
-  host  = module.simple_cluster.apiserver_url
+  # GitHub Actions does not have IPv6 connectivity. Shame.
+  host = module.simple_cluster.apiserver_url_v4
 
   client_certificate     = module.simple_cluster.client_certificate_data
   client_key             = module.simple_cluster.client_key_data
@@ -63,7 +64,8 @@ provider "kubernetes" {
 
 provider "kubernetes" {
   alias = "ha_cluster"
-  host  = module.ha_cluster.apiserver_url
+  # GitHub Actions does not have IPv6 connectivity. Shame.
+  host = module.ha_cluster.apiserver_url_v4
 
   client_certificate     = module.ha_cluster.client_certificate_data
   client_key             = module.ha_cluster.client_key_data

--- a/variables.tf
+++ b/variables.tf
@@ -9,13 +9,13 @@ variable "hcloud_ssh_key" {
 }
 
 variable "master_server_type" {
-  description = "Server SKU"
+  description = "Server SKU (default: 'cx31')"
   type        = string
   default     = "cx31"
 }
 
 variable "worker_server_type" {
-  description = "Server SKU"
+  description = "Server SKU (default: 'cx31')"
   type        = string
   default     = "cx31"
 }
@@ -33,13 +33,13 @@ variable "master_count" {
 }
 
 variable "control_plane_lb_type" {
-  description = "Hetzner token for CCM and storage provisioner"
+  description = "(Optional) Hetzner token for CCM and storage provisioner"
   type        = string
   default     = ""
 }
 
 variable "control_plane_endpoint" {
-  description = "Optional DNS name for the control plane endpoint"
+  description = "(Optional) DNS name for the control plane endpoint"
   type        = string
   default     = ""
 }
@@ -62,31 +62,31 @@ variable "worker_count" {
 }
 
 variable "image" {
-  description = "Image for the nodes"
+  description = "Image for the nodes (default: 'hel1')"
   type        = string
   default     = "ubuntu-20.04"
 }
 
 variable "location" {
-  description = "Server location"
+  description = "Server location (default: 'hel1')"
   type        = string
   default     = "hel1"
 }
 
 variable "ssh_private_key_path" {
-  description = "SSH public key file path"
+  description = "SSH public key file path (default: '~/.ssh/id_rsa')"
   type        = string
   default     = "~/.ssh/id_rsa"
 }
 
 variable "firewall_ids" {
-  description = "List of firewalls attached to the servers of the cluster"
+  description = "(Optional) List of firewalls attached to the servers of the cluster"
   type        = list(number)
   default     = []
 }
 
 variable "labels" {
-  description = "Additional labels"
+  description = "(Optional) Additional labels"
   type        = map(any)
   default     = {}
 }
@@ -95,4 +95,10 @@ variable "kubeadm_host" {
   description = "(Optional) The control plane node to use for management operations"
   type        = string
   default     = ""
+}
+
+variable "apiserver_extra_sans" {
+  description = "(Optional) Extra SANs for the apiserver certificate"
+  type        = list(any)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,9 @@ variable "labels" {
   type        = map(any)
   default     = {}
 }
+
+variable "kubeadm_host" {
+  description = "(Optional) The control plane node to use for management operations"
+  type        = string
+  default     = ""
+}

--- a/wireguard.tf
+++ b/wireguard.tf
@@ -1,0 +1,93 @@
+locals {
+  wireguard_peers = [for i, server in concat(module.master, module.worker) : {
+    public_key = server.wireguard_public_key
+    allowed_ips = [
+      "${server.private_ipv4_address}/32",
+      server.pod_subnet_v4,
+      server.ipv6_network,
+    ]
+    routes = [
+      "${server.private_ipv4_address}/32",
+      server.pod_subnet_v4,
+      server.pod_subnet_v6,
+    ]
+    endpoint = server.ipv6_address
+  }]
+}
+
+resource "null_resource" "master_wireguard" {
+  count = var.master_count
+
+  triggers = {
+    "id" : module.master[count.index].id
+    "peers" : jsonencode(local.wireguard_peers)
+  }
+
+  connection {
+    host        = module.master[count.index].ipv4_address
+    type        = "ssh"
+    timeout     = "5m"
+    user        = "root"
+    private_key = file(var.ssh_private_key_path)
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/wireguard.yaml.tpl", {
+      addresses = [
+        "${module.master[count.index].private_ipv4_address}/32"
+      ]
+      peers = concat(
+        slice(local.wireguard_peers, 0, count.index),
+        slice(local.wireguard_peers, count.index + 1, length(local.wireguard_peers))
+      )
+    })
+    destination = "/etc/netplan/60-wireguard.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      # Passing key by filename in netplan is only supported with systemd-network backend
+      "sed -i \"s#__PRIVATE_KEY__#$(cat /etc/wg_priv.key)#g\" /etc/netplan/60-wireguard.yaml",
+      "netplan apply",
+    ]
+  }
+}
+
+resource "null_resource" "worker_wireguard" {
+  count = var.worker_count
+
+  triggers = {
+    "id" : module.worker[count.index].id
+    "peers" : jsonencode(local.wireguard_peers)
+  }
+
+  connection {
+    host        = module.worker[count.index].ipv4_address
+    type        = "ssh"
+    timeout     = "5m"
+    user        = "root"
+    private_key = file(var.ssh_private_key_path)
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/wireguard.yaml.tpl", {
+      addresses = [
+        "${module.worker[count.index].private_ipv4_address}/32"
+      ]
+      peers = concat(
+        slice(local.wireguard_peers, 0, var.master_count + count.index),
+        slice(local.wireguard_peers, var.master_count + count.index + 1, length(local.wireguard_peers))
+      )
+
+    })
+    destination = "/etc/netplan/60-wireguard.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      # Passing key by filename in netplan is only supported with systemd-network backend
+      "sed -i \"s#__PRIVATE_KEY__#$(cat /etc/wg_priv.key)#g\" /etc/netplan/60-wireguard.yaml",
+      "netplan apply"
+    ]
+  }
+}


### PR DESCRIPTION
While Calico probably has the best IPv6 support among all networking plugins, it is still very broken. The magic it does with eBPF just seems to break kube-proxy ina very unpredictable ways.

This PR implements CNI integration from scratch with static host IPAM and Wireguard (to allow ingress filtering on `eth0` in the future)
