### PR TITLE
fix: Increase TTL of the bootstrap token used in cloud-init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ provider "kubernetes" {
 Once control plane is set up, module has an output called `join_user_data` that contains a cloud-init script that
 can be used to join additional worker nodes outside of Terraform (e.g. for use with [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/hetzner)).
 
+The generated join configuration will be valid for 10 years, after which the bootstrap token will need to be regenerated (but you should probably rebuild the cluster with something better by then).
+
 See [example](./examples/cloud_init.tf) for how it can be used to manage worker separately from this module.
 
 ## Caveats

--- a/joinconfig.tf
+++ b/joinconfig.tf
@@ -1,3 +1,8 @@
+locals {
+  # Bootstrap token valid for 10 years
+  bootstrap_token_ttl = 10 * 365 * 24
+}
+
 module "join_config" {
   source     = "matti/resource/shell"
   depends_on = [null_resource.cluster_bootstrap]
@@ -6,7 +11,7 @@ module "join_config" {
 
   command = <<EOT
     ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      root@${local.kubeadm_host} 'kubeadm token create --print-join-command'
+      root@${local.kubeadm_host} 'kubeadm token create --print-join-command --ttl=${local.bootstrap_token_ttl}h'
   EOT
 }
 


### PR DESCRIPTION
Currently the token is only valid for 24h. This increases it to 10 years.