### PR TITLE
prefer the ipv6 address to be returned as status.podIP

### DIFF
--- a/modules/kubernetes-node/scripts/prepare-node.sh
+++ b/modules/kubernetes-node/scripts/prepare-node.sh
@@ -41,7 +41,7 @@ containerd config default | \
 # Necessary for out-of-tree cloud providers as of 1.21.1 (soon to be deprecated)
 cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/20-hcloud.conf > /dev/null
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external"
+Environment="KUBELET_EXTRA_ARGS=--cloud-provider=external --node-ip=::"
 EOF
 
 sudo systemctl daemon-reload


### PR DESCRIPTION
certain services / deployments make use of `status.podIP` to get the pods ip address. in dualstack the status may look like this... but isnt by default. (figured with ceph and elastic (kibana)).

```
  podIP: 2a01:4f9:c011:4bdb:1::3
  podIPs:
  - ip: 2a01:4f9:c011:4bdb:1::3
  - ip: 10.96.3.3
```
adding the --node-ip=:: sets the returned value from status.podIP to the ipv6 address.
see the note here: 

```
k8s-master-0:~# kubelet -h | grep node-ip
      --node-ip string                                           IP address (or comma-separated dual-stack IP addresses) of the node. If unset, kubelet will use the node's default IPv4 address, if any, or its default IPv6 address if it has no IPv4 addresses. You can pass '::' to make it prefer the default IPv6 address rather than the default IPv4 address.
```

also see: 
https://github.com/kubernetes/kubernetes/issues/95251
https://github.com/kubernetes/kubernetes/issues/103263

how they use it for example in kibana / elastic
https://github.com/elastic/cloud-on-k8s/blob/ea74a401c38ec1acc4b8e28684ece63a42795422/deploy/eck-operator/templates/statefulset.yaml#L62