### PR TITLE
fix: Make use of shell resource more robust

### DIFF
--- a/joinconfig.tf
+++ b/joinconfig.tf
@@ -4,8 +4,10 @@ locals {
 }
 
 module "join_config" {
-  source     = "matti/resource/shell"
-  depends_on = [null_resource.cluster_bootstrap]
+  source        = "matti/resource/shell"
+  version       = "1.3.0"
+  depends_on    = [null_resource.cluster_bootstrap]
+  fail_on_error = true
 
   trigger = null_resource.cluster_bootstrap.id
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,17 +20,17 @@ output "apiserver_url" {
 
 output "client_certificate_data" {
   description = "kubeconfig for the cluster"
-  value       = base64decode(module.client_certificate_data.stdout)
+  value       = local.client_certificate_data
 }
 
 output "certificate_authority_data" {
   description = "kubeconfig for the cluster"
-  value       = base64decode(module.certificate_authority_data.stdout)
+  value       = local.certificate_authority_data
 }
 
 output "client_key_data" {
   description = "kubeconfig for the cluster"
-  value       = base64decode(module.client_key_data.stdout)
+  value       = local.client_key_data
 }
 
 output "kubeconfig" {


### PR DESCRIPTION
Addresses a potential cause of 
https://github.com/tibordp/terraform-hcloud-dualstack-k8s/issues/19

- Reduces the overall use of the shell resource - kubeconfig can be fetched via ssh from the master node only once, and the other outputs can be parsed out locally
- uses `fail_on_error = true` to ensure that we abort if we failed to load the data