### PR TITLE
feat: Upload kubeadm certs before joining a new control plane node

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -99,6 +99,15 @@ resource "null_resource" "master_join" {
   provisioner "local-exec" {
     command = <<EOT
       ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+          root@${local.kubeadm_host} 'kubeadm init phase upload-certs \
+            --upload-certs \
+            --certificate-key ${random_id.certificate_key.hex}'
+    EOT
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
         root@${local.kubeadm_host} \
         'echo $(kubeadm token create --print-join-command --ttl=60m) \
         --apiserver-advertise-address ${local.adverise_addresses[count.index]} \


### PR DESCRIPTION
- Upload kubeadm certs before every control plane node join (they have limited validity)
- Update docs to make it harder to accidentally break etcd when changing the master nodes 