### PR TITLE
feat: Hetzner Cloud private network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ See [example](./examples/cloud_init.tf) for how it can be used to manage worker 
 
 ## Using Hetzner Cloud private networks
 
-This module can be configured to use Hetzner Cloud private networks by specifying `use_hcloud_network`, `hcloud_network_id` and `hcloud_subnet_id` variables. In this case native routing will be used for IPv4 traffic and Wigglenet overlay will only be used for IPv6 traffic. Note that Hetzner private networks [are not encrypted](https://docs.hetzner.com/cloud/networks/faq#is-traffic-inside-hetzner-cloud-networks-encrypted), just segregated.
+This module can be configured to use Hetzner Cloud private networks by specifying `use_hcloud_network`, `hcloud_network_id` and `hcloud_subnet_id` variables. In this case native routing will be used for IPv4 traffic and Wigglenet overlay will only be used for IPv6 traffic (Hetnzer private networks are IPv4-only). Note that Hetzner private networks [are not encrypted](https://docs.hetzner.com/cloud/networks/faq#is-traffic-inside-hetzner-cloud-networks-encrypted), just segregated.
 
 See [example](./examples/private_network.tf) for more details.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Creates a Kubernetes cluster on the [Hetzner cloud](https://registry.terraform.i
   - the primary address family for the cluster is configurable, but defaults to IPv6, which is used for control plane communication
   - pods are allocated a private IPv4 address and a public IPv6 from the /64 subnet that Hetzner gives to every node. No masquerading needed for outbound IPv6 traffic! 🎉 (stateful firewall rules are still in place, so direct ingress traffic to pods is blocked by default, prefer to expose workloads through Service)
   - Dual-stack and IPv6-only `Service`s get a private (ULA) IPv6 address
-  - A full-mesh dynamic overlay network using Wireguard, so pod-to-pod traffic is encrypted (Hetzner private networks [are not encrypted](https://docs.hetzner.com/cloud/networks/faq#is-traffic-inside-hetzner-cloud-networks-encrypted), just segregated)
+  - A full-mesh dynamic overlay network using Wireguard, so pod-to-pod traffic is encrypted
 - deploys the [Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager) so `LoadBalancer` services provision Hetzner load balancers and deleted nodes are cleaned up.
 - deploys the [Container Storage Interface](https://github.com/hetznercloud/csi-driver) for dynamic provisioning of volumes
 - supports dynamic worker node provisioning with cloud-init e.g. for use with [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/hetzner)
@@ -161,6 +161,12 @@ can be used to join additional worker nodes outside of Terraform (e.g. for use w
 The generated join configuration will be valid for 10 years, after which the bootstrap token will need to be regenerated (but you should probably rebuild the cluster with something better by then).
 
 See [example](./examples/cloud_init.tf) for how it can be used to manage worker separately from this module.
+
+## Using Hetzner Cloud private networks
+
+This module can be configured to use Hetzner Cloud private networks by specifying `use_hcloud_network`, `hcloud_network_id` and `hcloud_subnet_id` variables. In this case native routing will be used for IPv4 traffic and Wigglenet overlay will only be used for IPv6 traffic. Note that Hetzner private networks [are not encrypted](https://docs.hetzner.com/cloud/networks/faq#is-traffic-inside-hetzner-cloud-networks-encrypted), just segregated.
+
+See [example](./examples/private_network.tf) for more details.
 
 ## Caveats
 

--- a/addons.tf
+++ b/addons.tf
@@ -6,8 +6,12 @@ resource "null_resource" "install_addons" {
   triggers = {
     wigglenet_manifest = templatefile("${path.module}/templates/wigglenet.yaml.tpl", {
       filter_pod_ingress_ipv6 = var.filter_pod_ingress_ipv6
+      native_routing_ipv4     = var.use_hcloud_network
     })
-    ccm_manifest = templatefile("${path.module}/templates/hetzner_ccm.yaml.tpl", {})
+    ccm_manifest = templatefile("${path.module}/templates/hetzner_ccm.yaml.tpl", {
+      use_hcloud_network = var.use_hcloud_network
+      pod_cidr_ipv4      = var.pod_cidr_ipv4
+    })
     csi_manifest = templatefile("${path.module}/templates/hetzner_csi.yaml.tpl", {})
     hcloud_token = var.hcloud_token
   }
@@ -43,7 +47,7 @@ resource "null_resource" "install_addons" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /root/install-addons.sh",
-      "HCLOUD_TOKEN='${var.hcloud_token}' /root/install-addons.sh",
+      "HCLOUD_TOKEN='${var.hcloud_token}' HCLOUD_NETWORK='${var.hcloud_network_id}' /root/install-addons.sh",
     ]
   }
 }

--- a/examples/private_network.tf
+++ b/examples/private_network.tf
@@ -1,0 +1,59 @@
+# A simple dual-stack cluster with Hetzner Cloud private networks
+
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "1.26.0"
+    }
+  }
+}
+
+variable "hetzner_token" {}
+
+provider "hcloud" {
+  token = vars.hetzner_token
+}
+
+resource "hcloud_ssh_key" "key" {
+  name       = "key"
+  public_key = file("~/.ssh/id_rsa.pub")
+}
+
+module "k8s" {
+  source = "tibordp/dualstack-k8s/hcloud"
+
+  name               = "k8s"
+  hcloud_ssh_key     = hcloud_ssh_key.key.id
+  hcloud_token       = vars.hetzner_token
+  location           = "hel1"
+  master_server_type = "cx31"
+  worker_server_type = "cx31"
+  worker_count       = 2
+
+  # The default pod_cidr_ipv6 is 10.96.0.0/16. This can be customized,
+  # but it should be within the range of the private network. Also, it should
+  # not overlap with the subnet specified below, as that subnet is used for nodes.
+  # pod_cidr_ipv4 = "10.96.0.0/16"
+
+  use_hcloud_network = true
+  hcloud_network_id  = hcloud_network.my_net.id
+  hcloud_subnet_id   = hcloud_network_subnet.my_subnet.id
+}
+
+resource "hcloud_network" "my_net" {
+  name     = "my-net"
+  ip_range = "10.0.0.0/8"
+}
+
+# This subnet is used for nodes
+resource "hcloud_network_subnet" "my_subnet" {
+  network_id   = hcloud_network.my_net.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.0.0/16"
+}
+
+output "simple_kubeconfig" {
+  value = module.k8s.kubeconfig
+}

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,13 @@
+resource "hcloud_server_network" "master_server_network" {
+  count = var.use_hcloud_network ? var.master_count : 0
+
+  server_id = module.master[count.index].id
+  subnet_id = var.hcloud_subnet_id
+}
+
+resource "hcloud_server_network" "worker_server_network" {
+  count = var.use_hcloud_network ? var.worker_count : 0
+
+  server_id = module.worker[count.index].id
+  subnet_id = var.hcloud_subnet_id
+}

--- a/scripts/install-addons.sh
+++ b/scripts/install-addons.sh
@@ -5,9 +5,17 @@ set -euo pipefail
 kubectl apply -f wigglenet.yaml
 
 # Install cloud provider
-kubectl -n kube-system create secret generic hcloud \
-    --from-literal=token="$HCLOUD_TOKEN" \
-    -o yaml --dry-run=client | kubectl apply -f-
+if [[ -z "${HCLOUD_NETWORK}" ]]; then
+    kubectl -n kube-system create secret generic hcloud \
+        --from-literal=token="$HCLOUD_TOKEN" \
+        -o yaml --dry-run=client | kubectl apply -f-
+else
+    kubectl -n kube-system create secret generic hcloud \
+        --from-literal=token="$HCLOUD_TOKEN" \
+        --from-literal=network="$HCLOUD_NETWORK" \
+        -o yaml --dry-run=client | kubectl apply -f-
+fi
+
 kubectl apply -f hetzner_ccm.yaml
 
 # Install storage provider

--- a/templates/hetzner_ccm.yaml.tpl
+++ b/templates/hetzner_ccm.yaml.tpl
@@ -63,6 +63,10 @@ spec:
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
             - "--allow-untagged-cloud"
+%{ if use_hcloud_network ~} 
+            - "--allocate-node-cidrs=true"
+            - "--cluster-cidr=${pod_cidr_ipv4}"
+%{ endif ~}          
           resources:
             requests:
               cpu: 100m
@@ -77,5 +81,12 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: token
+%{ if use_hcloud_network ~} 
+            - name: HCLOUD_NETWORK
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: network
+%{ endif ~}
             - name: HCLOUD_INSTANCES_ADDRESS_FAMILY
               value: dualstack                  

--- a/templates/wigglenet.yaml.tpl
+++ b/templates/wigglenet.yaml.tpl
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: wigglenet
       containers:
       - name: wigglenet
-        image: tibordp/wigglenet:0.2.2
+        image: tibordp/wigglenet:0.2.3
         imagePullPolicy: Always
         env:
         - name: NODE_NAME
@@ -77,10 +77,6 @@ spec:
           # outside the cluster          
         - name: FILTER_IPV6
           value: "${filter_pod_ingress_ipv6}" 
-          # Optional interface from which to take the node's
-          # IP address (default: none)        
-        - name: NODE_IP_INTERFACES
-          value: "eth0"     
           # The source of IPv6 subnets for node pod networks
           # ("none", "spec", "file")
         - name: POD_CIDR_SOURCE_IPV4
@@ -92,7 +88,11 @@ spec:
           # The file from which to read the pod CIDRs if "file"
           # mode is used
         - name: POD_CIDR_SOURCE_PATH
-          value: "/etc/wigglenet/cidrs.txt"        
+          value: "/etc/wigglenet/cidrs.txt"      
+          # Use native routing instead of the overlay network
+          # for IPv4 traffic
+        - name: NATIVE_ROUTING_IPV4
+          value: "${native_routing_ipv4}"
         volumeMounts:
         - name: cfg
           mountPath: /etc/wigglenet

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,21 @@ variable "kubernetes_version" {
   type        = string
   default     = "1.22.0"
 }
+
+variable "use_hcloud_network" {
+  description = "Use Hetzner private network (default: false)"
+  type        = bool
+  default     = false
+}
+
+variable "hcloud_network_id" {
+  description = "(Optional) Hetzner private network ID"
+  type        = string
+  default     = ""
+}
+
+variable "hcloud_subnet_id" {
+  description = "(Optional) Hetzner private network ID"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Closes #25 

This PR adds optional support for Hetzner Cloud private networks (IPv4 only)