### PR TITLE
chore: Dependency upgrades and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ module "k8s" {
   worker_server_type = "cx31"
   worker_count       = 2
 
-  kubernetes_version = "1.22.0"
+  kubernetes_version = "1.22.2"
 }
 
 output "kubeconfig" {
-  value = module.k8s.kubeconfig
+  value     = module.k8s.kubeconfig
+  sensitive = true
 }
 ```
 
@@ -60,9 +61,9 @@ and check the access by viewing the created cluster nodes:
 ```cmd
 $ kubectl get nodes --kubeconfig=kubeconfig.conf
 NAME           STATUS   ROLES                  AGE   VERSION
-k8s-master-0   Ready    control-plane,master   31m   v1.22.0
-k8s-worker-0   Ready    <none>                 31m   v1.22.0
-k8s-worker-1   Ready    <none>                 31m   v1.22.0
+k8s-master-0   Ready    control-plane,master   31m   v1.22.2
+k8s-worker-0   Ready    <none>                 31m   v1.22.2
+k8s-worker-1   Ready    <none>                 31m   v1.22.2
 ```
 
 ## High availability setup

--- a/examples/cloud_init.tf
+++ b/examples/cloud_init.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.26.0"
+      version = "1.31.1"
     }
   }
 }
@@ -45,5 +45,6 @@ resource "hcloud_server" "instance" {
 
 
 output "simple_kubeconfig" {
-  value = module.k8s.kubeconfig
+  value     = module.k8s.kubeconfig
+  sensitive = true
 }

--- a/examples/ha_dns_name.tf
+++ b/examples/ha_dns_name.tf
@@ -4,15 +4,13 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.26.0"
+      version = "1.31.1"
     }
     aws = {
       source  = "hashicorp/aws"
       version = "~> 3.27"
     }
   }
-
-  required_version = ">= 0.14.9"
 }
 
 variable "hetzner_token" {}
@@ -65,5 +63,6 @@ resource "aws_route53_record" "api_server_a" {
 }
 
 output "kubeconfig" {
-  value = module.k8s.kubeconfig
+  value     = module.k8s.kubeconfig
+  sensitive = true
 }

--- a/examples/ha_load_balancer.tf
+++ b/examples/ha_load_balancer.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.26.0"
+      version = "1.31.1"
     }
   }
 }
@@ -46,5 +46,6 @@ output "load_balancer_ipv6" {
 }
 
 output "ha_cluster_kubeconfig" {
-  value = module.k8s.kubeconfig
+  value     = module.k8s.kubeconfig
+  sensitive = true
 }

--- a/examples/private_network.tf
+++ b/examples/private_network.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.26.0"
+      version = "1.31.1"
     }
   }
 }
@@ -55,5 +55,6 @@ resource "hcloud_network_subnet" "my_subnet" {
 }
 
 output "simple_kubeconfig" {
-  value = module.k8s.kubeconfig
+  value     = module.k8s.kubeconfig
+  sensitive = true
 }

--- a/examples/simple.tf
+++ b/examples/simple.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.26.0"
+      version = "1.31.1"
     }
   }
 }
@@ -33,5 +33,6 @@ module "k8s" {
 }
 
 output "simple_kubeconfig" {
-  value = module.k8s.kubeconfig
+  value     = module.k8s.kubeconfig
+  sensitive = true
 }

--- a/joinconfig.tf
+++ b/joinconfig.tf
@@ -4,10 +4,11 @@ locals {
 }
 
 module "join_config" {
-  source        = "matti/resource/shell"
-  version       = "1.3.0"
-  depends_on    = [null_resource.cluster_bootstrap]
-  fail_on_error = true
+  source            = "matti/resource/shell"
+  version           = "1.5.0"
+  depends_on        = [null_resource.cluster_bootstrap]
+  fail_on_error     = true
+  sensitive_outputs = true
 
   trigger = null_resource.cluster_bootstrap.id
 
@@ -17,7 +18,7 @@ module "join_config" {
   EOT
 }
 
-data "template_cloudinit_config" "join_config" {
+data "cloudinit_config" "join_config" {
   gzip          = true
   base64_encode = true
 

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -1,8 +1,9 @@
 module "kubeconfig" {
-  source        = "matti/resource/shell"
-  version       = "1.3.0"
-  depends_on    = [null_resource.cluster_bootstrap]
-  fail_on_error = true
+  source            = "matti/resource/shell"
+  version           = "1.5.0"
+  depends_on        = [null_resource.cluster_bootstrap]
+  fail_on_error     = true
+  sensitive_outputs = true
 
   trigger = null_resource.cluster_bootstrap.id
 
@@ -14,7 +15,7 @@ module "kubeconfig" {
 
 locals {
   kubeconfig                 = yamldecode(module.kubeconfig.stdout)
-  certificate_authority_data = base64decode(local.kubeconfig.clusters[0].cluster.certificate-authority-data)
-  client_certificate_data    = base64decode(local.kubeconfig.users[0].user.client-certificate-data)
+  certificate_authority_data = nonsensitive(base64decode(local.kubeconfig.clusters[0].cluster.certificate-authority-data))
+  client_certificate_data    = nonsensitive(base64decode(local.kubeconfig.users[0].user.client-certificate-data))
   client_key_data            = base64decode(local.kubeconfig.users[0].user.client-key-data)
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,11 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.26.0"
+      version = "~> 1.31"
+    }
+    template = {
+      source  = "hashicorp/cloudinit"
+      version = "2.2.0"
     }
   }
 }

--- a/master.tf
+++ b/master.tf
@@ -114,7 +114,7 @@ resource "null_resource" "master_join" {
         --control-plane \
         --certificate-key ${random_id.certificate_key.hex}' | \
       ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        root@${module.master[count.index].ipv4_address} 'tee /root/join-command.sh'
+        root@${module.master[count.index].ipv4_address} 'tee /root/join-command.sh >/dev/null'
     EOT
   }
 

--- a/modules/kubernetes-node/main.tf
+++ b/modules/kubernetes-node/main.tf
@@ -2,11 +2,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.26.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
+      version = "~> 1.31"
     }
   }
 }

--- a/modules/kubernetes-node/scripts/prepare-node.sh.tpl
+++ b/modules/kubernetes-node/scripts/prepare-node.sh.tpl
@@ -18,8 +18,8 @@ EOF
 sudo sysctl --system
 
 # Install prerequisites
-sudo apt-get update -qq
-sudo apt-get install -qq apt-transport-https ca-certificates curl gnupg lsb-release ipvsadm wireguard
+sudo apt-get -qq update
+sudo apt-get -qq install apt-transport-https ca-certificates curl gnupg lsb-release ipvsadm wireguard
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-archive-keyring.gpg
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
@@ -28,8 +28,8 @@ echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https:/
   sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
 
 # Install container runtime and Kubernetes
-sudo apt-get update -qq
-sudo apt-get install -qq containerd.io kubelet=${kubernetes_version}-00 kubeadm=${kubernetes_version}-00 kubectl=${kubernetes_version}-00
+sudo apt-get -qq update
+sudo apt-get -qq install containerd.io kubelet=${kubernetes_version}-00 kubeadm=${kubernetes_version}-00 kubectl=${kubernetes_version}-00
 sudo apt-mark hold kubelet kubeadm kubectl
 
 # Enable systemd cgroups driver

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,26 +19,29 @@ output "apiserver_url" {
 }
 
 output "client_certificate_data" {
-  description = "kubeconfig for the cluster"
+  description = "client certificate"
   value       = local.client_certificate_data
 }
 
 output "certificate_authority_data" {
-  description = "kubeconfig for the cluster"
+  description = "cluster CA certificate"
   value       = local.certificate_authority_data
 }
 
 output "client_key_data" {
-  description = "kubeconfig for the cluster"
+  description = "client certificate private key"
   value       = local.client_key_data
+  sensitive   = true
 }
 
 output "kubeconfig" {
   description = "kubeconfig for the cluster"
   value       = module.kubeconfig.stdout
+  sensitive   = true
 }
 
 output "join_user_data" {
   description = "cloud-init user data for additional worker nodes"
-  value       = data.template_cloudinit_config.join_config.rendered
+  value       = data.cloudinit_config.join_config.rendered
+  sensitive   = true
 }

--- a/templates/hetzner_ccm.yaml.tpl
+++ b/templates/hetzner_ccm.yaml.tpl
@@ -56,7 +56,7 @@ spec:
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.11.1
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.12.0
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"

--- a/templates/wigglenet.yaml.tpl
+++ b/templates/wigglenet.yaml.tpl
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: wigglenet
       containers:
       - name: wigglenet
-        image: tibordp/wigglenet:0.2.3
+        image: tibordp/wigglenet:v0.3.0
         imagePullPolicy: Always
         env:
         - name: NODE_NAME

--- a/test/main.tf
+++ b/test/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.26.0"
+      version = "1.31.1"
     }
   }
 }
@@ -56,6 +56,7 @@ output "simple_cluster" {
     "/server: .*/",
     "server: https://${module.simple_cluster.masters[0].ipv4_address}:6443"
   )
+  sensitive = true
 }
 
 output "ha_cluster" {
@@ -64,4 +65,5 @@ output "ha_cluster" {
     "/server: .*/",
     "server: https://${module.ha_cluster.load_balancer.ipv4}:6443"
   )
+  sensitive = true
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -17,7 +17,7 @@ teardown_cluster() {
 
 case "$1" in
 kubectl)
-    curl -LO https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl
+    curl -LO https://dl.k8s.io/release/v1.22.2/bin/linux/amd64/kubectl
     chmod +x kubectl
     ;;
 setup)

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "worker_server_type" {
 variable "hcloud_token" {
   description = "Hetzner token for CCM and storage provisioner"
   type        = string
-  # sensitive   = true
+  sensitive   = true
 }
 
 variable "master_count" {
@@ -128,9 +128,9 @@ variable "primary_ip_family" {
 }
 
 variable "kubernetes_version" {
-  description = "Version of Kubernetes to install (default: 1.22.0)"
+  description = "Version of Kubernetes to install (default: 1.22.2)"
   type        = string
-  default     = "1.22.0"
+  default     = "1.22.2"
 }
 
 variable "use_hcloud_network" {


### PR DESCRIPTION
A bunch of dependency upgrades and cleanup

- Upgrade the Hetzner CCM to v1.12.0
- Upgrade Hetzner CSI to v1.6.0
- Upgrade Wigglenet to v0.3.0
- Bump matti/resource/shell to 1.5.0
- Switch from deprecated hashicorp/template to hashicorp/cloudinit
- Bump default Kubernetes version to 1.22.2
- Bump minimum required hcloud Terraform provider to 1.31.0
- Mark certain inputs and outputs of the module as sensitive