### PR TITLE
get the name of the distribution on node

### DIFF
--- a/modules/kubernetes-node/scripts/prepare-node.sh.tpl
+++ b/modules/kubernetes-node/scripts/prepare-node.sh.tpl
@@ -20,9 +20,9 @@ sudo sysctl --system
 # Install prerequisites
 sudo apt-get -qq update
 sudo apt-get -qq install apt-transport-https ca-certificates curl gnupg lsb-release ipvsadm wireguard
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo $ID)/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-archive-keyring.gpg
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/$(. /etc/os-release && echo $ID) $(lsb_release -cs) stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | \
   sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null

--- a/modules/kubernetes-node/scripts/prepare-node.sh.tpl
+++ b/modules/kubernetes-node/scripts/prepare-node.sh.tpl
@@ -4,10 +4,12 @@ set -euo pipefail
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip6_tables
 EOF
 
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip6_tables
 # Setup required sysctl params, these persist across reboots.
 cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
 net.bridge.bridge-nf-call-iptables  = 1
@@ -19,7 +21,7 @@ sudo sysctl --system
 
 # Install prerequisites
 sudo apt-get -qq update
-sudo apt-get -qq install apt-transport-https ca-certificates curl gnupg lsb-release ipvsadm wireguard
+sudo apt-get -qq install apt-transport-https ca-certificates curl gnupg lsb-release ipvsadm wireguard apparmor
 curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo $ID)/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-archive-keyring.gpg
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/$(. /etc/os-release && echo $ID) $(lsb_release -cs) stable" | \


### PR DESCRIPTION
Hi! It's simple fix for opportunity to get the name of the distribution, so that we can download docker not only for ubuntu