### PR TITLE
feat: Add support for CentOS-like base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module "k8s" {
   worker_server_type = "cx31"
   worker_count       = 2
 
-  kubernetes_version = "1.22.2"
+  kubernetes_version = "1.23.4"
 }
 
 output "kubeconfig" {
@@ -61,10 +61,21 @@ and check the access by viewing the created cluster nodes:
 ```cmd
 $ kubectl get nodes --kubeconfig=kubeconfig.conf
 NAME           STATUS   ROLES                  AGE   VERSION
-k8s-master-0   Ready    control-plane,master   31m   v1.22.2
-k8s-worker-0   Ready    <none>                 31m   v1.22.2
-k8s-worker-1   Ready    <none>                 31m   v1.22.2
+k8s-master-0   Ready    control-plane,master   31m   v1.23.4
+k8s-worker-0   Ready    <none>                 31m   v1.23.4
+k8s-worker-1   Ready    <none>                 31m   v1.23.4
 ```
+
+## Supported base images
+
+The module should work on most major RPM and DEB distros. It been tested on these base images, others may work as well, but have not been tested:
+
+- Ubuntu 20.04 (`ubuntu-20.04`)
+- Debian 11 (`debian-11`)
+- Centos Stream 8 (`centos-stream-8`)
+- Rocky Linux 8 (`rocky-8`)
+
+Fedora 35 is currently not supported due to Terraform SSH issue (see https://github.com/hashicorp/terraform/issues/30134).
 
 ## High availability setup
 

--- a/modules/kubernetes-node/main.tf
+++ b/modules/kubernetes-node/main.tf
@@ -7,10 +7,27 @@ terraform {
   }
 }
 
+locals {
+  provision_scripts = {
+    ubuntu = "prepare-debian-like.sh.tpl",
+    debian = "prepare-debian-like.sh.tpl",
+    centos = "prepare-centos-like.sh.tpl",
+    fedora = "prepare-centos-like.sh.tpl",
+    rocky  = "prepare-centos-like.sh.tpl",
+  }
+  provision_script = templatefile("${path.module}/scripts/${local.provision_scripts[data.hcloud_image.image.os_flavor]}", {
+    kubernetes_version = var.kubernetes_version
+  })
+}
+
+data "hcloud_image" "image" {
+  name = var.image
+}
+
 resource "hcloud_server" "instance" {
   name        = var.name
   ssh_keys    = [var.hcloud_ssh_key]
-  image       = var.image
+  image       = data.hcloud_image.image.id
   location    = var.location
   server_type = var.server_type
 
@@ -26,9 +43,7 @@ resource "hcloud_server" "instance" {
   }
 
   provisioner "file" {
-    content = templatefile("${path.module}/scripts/prepare-node.sh.tpl", {
-      kubernetes_version = var.kubernetes_version
-    })
+    content     = local.provision_script
     destination = "/root/prepare-node.sh"
   }
 

--- a/modules/kubernetes-node/scripts/prepare-centos-like.sh.tpl
+++ b/modules/kubernetes-node/scripts/prepare-centos-like.sh.tpl
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+# Kernel modules
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf > /dev/null
+overlay
+br_netfilter
+ip_tables
+ip6_tables
+wireguard
+EOF
+sudo modprobe -a overlay br_netfilter ip_tables ip6_tables
+
+# Setup required sysctl params, these persist across reboots.
+cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf > /dev/null
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.ipv6.conf.all.forwarding        = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+sudo sysctl --system
+
+# Install prerequisites
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo > /dev/null
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kubelet kubeadm kubectl
+EOF
+
+sudo dnf -qy config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo dnf -qy install elrepo-release epel-release
+sudo dnf -qy install containerd.io ipvsadm kmod-wireguard wireguard-tools iproute-tc
+
+# Load Wireguard kernel module
+sudo modprobe wireguard
+
+# Enable systemd cgroups driver
+sudo mkdir -p /etc/containerd
+containerd config default | \
+  grep -v 'SystemdCgroup' | \
+  sed -re 's/(\s+)(\[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options\])/\1\2\n\1  SystemdCgroup = true/g' | \
+  sudo tee /etc/containerd/config.toml >/dev/null
+
+# Disable SELinux, if it is enabled
+if [ "$(getenforce)" != "Permissive" ]; then
+    sudo setenforce 0
+    sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+fi
+
+cat <<EOF | sudo tee /etc/sysconfig/kubelet > /dev/null
+KUBELET_EXTRA_ARGS=--cloud-provider=external --node-ip=::
+EOF
+
+sudo dnf -qy install kubelet-${kubernetes_version}-0 kubeadm-${kubernetes_version}-0 kubectl-${kubernetes_version}-0 --disableexcludes=kubernetes
+sudo systemctl enable --now containerd kubelet 
+
+# Determine the IPv6 pod subnet based on the /64 assigned to eth0 interface (take 2nd /80)
+sudo mkdir -p /etc/wigglenet
+sudo python3 <<EOF
+import re
+import os
+import ipaddress
+import itertools
+
+addrs = os.popen("ip -6 addr show eth0 scope global").read()
+addr = re.search(r"inet6 ([^ ]+/64) scope global", addrs, re.MULTILINE).group(1)
+net = ipaddress.IPv6Network(addr, strict=False)
+pod_subnet = next(itertools.islice(net.subnets(16), 1, None))
+
+with open("/etc/wigglenet/cidrs.txt", "w") as f:
+    print(pod_subnet, file=f)
+
+print(f"Pod CIDR is {pod_subnet}")
+EOF

--- a/templates/hetzner_ccm.yaml.tpl
+++ b/templates/hetzner_ccm.yaml.tpl
@@ -51,12 +51,14 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+          operator: Exists          
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
+          operator: Exists          
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.12.0
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.12.1
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"

--- a/templates/wigglenet.yaml.tpl
+++ b/templates/wigglenet.yaml.tpl
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: wigglenet
       containers:
       - name: wigglenet
-        image: tibordp/wigglenet:v0.3.0
+        image: tibordp/wigglenet:v0.3.1
         imagePullPolicy: Always
         env:
         - name: NODE_NAME

--- a/test/test.sh
+++ b/test/test.sh
@@ -17,7 +17,7 @@ teardown_cluster() {
 
 case "$1" in
 kubectl)
-    curl -LO https://dl.k8s.io/release/v1.22.2/bin/linux/amd64/kubectl
+    curl -LO https://dl.k8s.io/release/v1.23.4/bin/linux/amd64/kubectl
     chmod +x kubectl
     ;;
 setup)

--- a/variables.tf
+++ b/variables.tf
@@ -128,9 +128,9 @@ variable "primary_ip_family" {
 }
 
 variable "kubernetes_version" {
-  description = "Version of Kubernetes to install (default: 1.22.2)"
+  description = "Version of Kubernetes to install (default: 1.23.4)"
   type        = string
-  default     = "1.22.2"
+  default     = "1.23.4"
 }
 
 variable "use_hcloud_network" {


### PR DESCRIPTION
This PR adds support for RPM-based base images like CentOS and Rocky Linux.

Fedora 35 support is planned too, but currently it's impossible to test reliably due to an upstream issue:
https://github.com/hashicorp/terraform/issues/30134

Also bumps default Kubernetes version to 1.23.4