### PR TITLE
chore: Upgrade dependencies + default to v1.28.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_wrapper: false
 

--- a/.github/workflows/lint_terraform.yml
+++ b/.github/workflows/lint_terraform.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
 
     - name: Terraform Init
       run: terraform init

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module "worker_nodes" {
 }
 
 output "kubeconfig" {
-  value     = module.k8s.kubeconfig
+  value     = module.cluster.kubeconfig
   sensitive = true
 }
 ```
@@ -69,9 +69,9 @@ and check the access by viewing the created cluster nodes:
 ```cmd
 $ kubectl get nodes --kubeconfig=kubeconfig.conf
 NAME                  STATUS   ROLES           AGE   VERSION
-k8s-control-plane-0   Ready    control-plane   31m   v1.27.1
-k8s-worker-0          Ready    <none>          31m   v1.27.1
-k8s-worker-1          Ready    <none>          31m   v1.27.1
+k8s-control-plane-0   Ready    control-plane   31m   v1.28.3
+k8s-worker-0          Ready    <none>          31m   v1.28.3
+k8s-worker-1          Ready    <none>          31m   v1.28.3
 ```
 
 ## Supported base images
@@ -79,12 +79,10 @@ k8s-worker-1          Ready    <none>          31m   v1.27.1
 The module should work on most major RPM and DEB distros. It been tested on these base images:
 
 - Ubuntu 22.04 (`ubuntu-22.04`)
-- Debian 11 (`debian-11`)
-- Centos Stream 8 (`centos-stream-8`)
+- Debian 12 (`debian-12`)
 - Centos Stream 9 (`centos-stream-9`)
-- Rocky Linux 8 (`rocky-8`)
 - Rocky Linux 9 (`rocky-9`)
-- Fedora 37 (`fedora-37`)
+- Fedora 38 (`fedora-38`)
 
 Others may work as well, but have not been tested.
 

--- a/joinconfig.tf
+++ b/joinconfig.tf
@@ -3,6 +3,7 @@ locals {
   bootstrap_token_ttl = 10 * 365 * 24
   provision_script = templatefile("${path.module}/modules/kubernetes-node/scripts/prepare-node.sh.tpl", {
     kubernetes_version = var.kubernetes_version
+    kubernetes_minor_version = replace(var.kubernetes_version, "/^(\\d+\\.\\d+).*$/", "$1")
   })
 }
 

--- a/joinconfig.tf
+++ b/joinconfig.tf
@@ -2,7 +2,7 @@ locals {
   # Bootstrap token valid for 10 years
   bootstrap_token_ttl = 10 * 365 * 24
   provision_script = templatefile("${path.module}/modules/kubernetes-node/scripts/prepare-node.sh.tpl", {
-    kubernetes_version = var.kubernetes_version
+    kubernetes_version       = var.kubernetes_version
     kubernetes_minor_version = replace(var.kubernetes_version, "/^(\\d+\\.\\d+).*$/", "$1")
   })
 }

--- a/modules/kubernetes-node/main.tf
+++ b/modules/kubernetes-node/main.tf
@@ -10,6 +10,7 @@ terraform {
 locals {
   provision_script = templatefile("${path.module}/scripts/prepare-node.sh.tpl", {
     kubernetes_version = var.kubernetes_version
+    kubernetes_minor_version = replace(var.kubernetes_version, "/^(\\d+\\.\\d+).*$/", "$1")
   })
 }
 

--- a/modules/kubernetes-node/main.tf
+++ b/modules/kubernetes-node/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 locals {
   provision_script = templatefile("${path.module}/scripts/prepare-node.sh.tpl", {
-    kubernetes_version = var.kubernetes_version
+    kubernetes_version       = var.kubernetes_version
     kubernetes_minor_version = replace(var.kubernetes_version, "/^(\\d+\\.\\d+).*$/", "$1")
   })
 }

--- a/modules/kubernetes-node/variables.tf
+++ b/modules/kubernetes-node/variables.tf
@@ -21,6 +21,11 @@ variable "image" {
 variable "kubernetes_version" {
   description = "Kubernetes version"
   type        = string
+
+  validation {
+    condition     = can(regex("^1\\.([0-9]+)\\.([0-9]+)$", var.kubernetes_version))
+    error_message = "The kubernetes_version value must be a \"1.x.y\"."
+  }
 }
 
 variable "location" {

--- a/modules/worker-node/variables.tf
+++ b/modules/worker-node/variables.tf
@@ -49,9 +49,14 @@ variable "labels" {
 }
 
 variable "kubernetes_version" {
-  description = "Version of Kubernetes to install (default: 1.27.1)"
+  description = "Kubernetes version"
   type        = string
-  default     = "1.27.1"
+  default     = "1.28.3"
+
+  validation {
+    condition     = can(regex("^1\\.([0-9]+)\\.([0-9]+)$", var.kubernetes_version))
+    error_message = "The kubernetes_version value must be a \"1.x.y\"."
+  }
 }
 
 variable "use_hcloud_network" {

--- a/templates/hetzner_csi.yaml.tpl
+++ b/templates/hetzner_csi.yaml.tpl
@@ -1,159 +1,97 @@
-allowVolumeExpansion: true
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-  name: hcloud-volumes
-provisioner: csi.hetzner.cloud
-volumeBindingMode: WaitForFirstConsumer
 ---
+# Source: hcloud-csi/templates/controller/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hcloud-csi-controller
-  namespace: kube-system
+  namespace: "kube-system"
+  labels:
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: controller
+automountServiceAccountToken: true
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+# Source: hcloud-csi/templates/core/storageclass.yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: hcloud-volumes
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.hetzner.cloud
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: "Delete"
+---
+# Source: hcloud-csi/templates/controller/clusterrole.yaml
 kind: ClusterRole
-metadata:
-  name: hcloud-csi-controller
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - persistentvolumes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - csi.storage.k8s.io
-    resources:
-      - csinodeinfos
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      - csinodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      - volumeattachments
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      - volumeattachments/status
-    verbs:
-      - patch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - ""
-    resources:
-      - persistentvolumes
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-  - apiGroups:
-      - ""
-    resources:
-      - persistentvolumeclaims
-      - persistentvolumeclaims/status
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      - storageclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - list
-      - watch
-      - create
-      - update
-      - patch
-  - apiGroups:
-      - snapshot.storage.k8s.io
-    resources:
-      - volumesnapshots
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - snapshot.storage.k8s.io
-    resources:
-      - volumesnapshotcontents
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
 metadata:
   name: hcloud-csi-controller
+  labels:
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: controller
+rules:
+# attacher
+- apiGroups: [""]
+  resources: [persistentvolumes]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [""]
+  resources: [nodes]
+  verbs: [get, list, watch]
+- apiGroups: [csi.storage.k8s.io]
+  resources: [csinodeinfos]
+  verbs: [get, list, watch]
+- apiGroups: [storage.k8s.io]
+  resources: [csinodes]
+  verbs: [get, list, watch]
+- apiGroups: [storage.k8s.io]
+  resources: [volumeattachments]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [storage.k8s.io]
+  resources: [volumeattachments/status]
+  verbs: [patch]
+# provisioner
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: [get, list]
+- apiGroups: [""]
+  resources: [persistentvolumes]
+  verbs: [get, list, watch, create, delete, patch]
+- apiGroups: [""]
+  resources: [persistentvolumeclaims, persistentvolumeclaims/status]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [storage.k8s.io]
+  resources: [storageclasses]
+  verbs: [get, list, watch]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [list, watch, create, update, patch]
+- apiGroups: [snapshot.storage.k8s.io]
+  resources: [volumesnapshots]
+  verbs: [get, list]
+- apiGroups: [snapshot.storage.k8s.io]
+  resources: [volumesnapshotcontents]
+  verbs: [get, list]
+# resizer
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+# node
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch, create, update, patch]
+---
+# Source: hcloud-csi/templates/controller/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hcloud-csi-controller
+  labels:
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -161,81 +99,257 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: hcloud-csi-controller
-    namespace: kube-system
+    namespace: "kube-system"
 ---
+# Source: hcloud-csi/templates/controller/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: hcloud-csi-controller
   name: hcloud-csi-controller-metrics
-  namespace: kube-system
+  namespace: "kube-system"
+  labels:
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: controller
 spec:
   ports:
     - name: metrics
       port: 9189
-      targetPort: metrics
   selector:
-    app: hcloud-csi-controller
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: controller
 ---
+# Source: hcloud-csi/templates/node/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: hcloud-csi
   name: hcloud-csi-node-metrics
-  namespace: kube-system
+  namespace: "kube-system"
+  labels:
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: node
 spec:
   ports:
     - name: metrics
       port: 9189
-      targetPort: metrics
   selector:
-    app: hcloud-csi
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: node
 ---
+# Source: hcloud-csi/templates/node/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hcloud-csi-node
+  namespace: "kube-system"
+  labels:
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: node
+    app: hcloud-csi
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: hcloud-csi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hcloud-csi
+        app.kubernetes.io/instance: hcloud-csi
+        app.kubernetes.io/component: node
+        app: hcloud-csi
+    spec:
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: instance.hetzner.cloud/is-root-server
+                operator: NotIn
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+      containers:
+        - name: csi-node-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /run/csi
+            - name: registration-dir
+              mountPath: /registration
+          resources:
+            limits: {}
+            requests: {}
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - mountPath: /run/csi
+            name: plugin-dir
+          resources:
+            limits: {}
+            requests: {}
+        - name: hcloud-csi-driver
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.5.1 # x-release-please-version
+          imagePullPolicy: IfNotPresent
+          command: [/bin/hcloud-csi-driver-node]
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /run/csi
+            - name: device-dir
+              mountPath: /dev
+          securityContext:
+            privileged: true
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///run/csi/socket
+            - name: METRICS_ENDPOINT
+              value: "0.0.0.0:9189"
+            - name: ENABLE_METRICS
+              value: "true"
+          ports:
+            - containerPort: 9189
+              name: metrics
+            - name: healthz
+              protocol: TCP
+              containerPort: 9808
+          resources:
+            limits: {}
+            requests: {}
+          livenessProbe:
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 3
+            httpGet:
+              path: /healthz
+              port: healthz
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+---
+# Source: hcloud-csi/templates/controller/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hcloud-csi-controller
-  namespace: kube-system
+  namespace: "kube-system"
+  labels:
+    app.kubernetes.io/name: hcloud-csi
+    app.kubernetes.io/instance: hcloud-csi
+    app.kubernetes.io/component: controller
+    app: hcloud-csi-controller
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: hcloud-csi-controller
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: hcloud-csi
+        app.kubernetes.io/instance: hcloud-csi
+        app.kubernetes.io/component: controller
         app: hcloud-csi-controller
     spec:
+      serviceAccountName: hcloud-csi-controller
+
+      securityContext:
+        fsGroup: 1001
+      initContainers:
       containers:
-        - args:
-            - --default-fstype=ext4
+        - name: csi-attacher
           image: registry.k8s.io/sig-storage/csi-attacher:v4.1.0
-          name: csi-attacher
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
+          args:
+            - --default-fstype=ext4
           volumeMounts:
-            - mountPath: /run/csi
-              name: socket-dir
-        - image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
-          name: csi-resizer
+          - name: socket-dir
+            mountPath: /run/csi
+
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
           volumeMounts:
-            - mountPath: /run/csi
-              name: socket-dir
-        - args:
+          - name: socket-dir
+            mountPath: /run/csi
+
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
+          args:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
-          name: csi-provisioner
           volumeMounts:
-            - mountPath: /run/csi
-              name: socket-dir
-        - command:
-            - /bin/hcloud-csi-driver-controller
+          - name: socket-dir
+            mountPath: /run/csi
+
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+          - mountPath: /run/csi
+            name: socket-dir
+
+        - name: hcloud-csi-driver
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.5.1 # x-release-please-version
+          imagePullPolicy: IfNotPresent
+          command: [/bin/hcloud-csi-driver-controller]
           env:
             - name: CSI_ENDPOINT
               value: unix:///run/csi/socket
             - name: METRICS_ENDPOINT
-              value: 0.0.0.0:9189
+              value: "0.0.0.0:9189"
             - name: ENABLE_METRICS
               value: "true"
             - name: KUBE_NODE_NAME
@@ -246,141 +360,35 @@ spec:
             - name: HCLOUD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  key: token
                   name: hcloud
-          image: hetznercloud/hcloud-csi-driver:v2.3.2
-          imagePullPolicy: Always
+                  key: token
+          resources:
+            limits: {}
+            requests: {}
+          ports:
+            - name: metrics
+              containerPort: 9189
+            - name: healthz
+              protocol: TCP
+              containerPort: 9808
           livenessProbe:
             failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 3
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 10
-            periodSeconds: 2
-            timeoutSeconds: 3
-          name: hcloud-csi-driver
-          ports:
-            - containerPort: 9189
-              name: metrics
-            - containerPort: 9808
-              name: healthz
-              protocol: TCP
           volumeMounts:
-            - mountPath: /run/csi
-              name: socket-dir
-        - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
-          imagePullPolicy: Always
-          name: liveness-probe
-          volumeMounts:
-            - mountPath: /run/csi
-              name: socket-dir
-      serviceAccountName: hcloud-csi-controller
+            - name: socket-dir
+              mountPath: /run/csi
+
       volumes:
-        - emptyDir: {}
-          name: socket-dir
+        - name: socket-dir
+          emptyDir: {}
 ---
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app: hcloud-csi
-  name: hcloud-csi-node
-  namespace: kube-system
-spec:
-  selector:
-    matchLabels:
-      app: hcloud-csi
-  template:
-    metadata:
-      labels:
-        app: hcloud-csi
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: instance.hetzner.cloud/is-root-server
-                    operator: NotIn
-                    values:
-                      - "true"
-      containers:
-        - args:
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
-          name: csi-node-driver-registrar
-          volumeMounts:
-            - mountPath: /run/csi
-              name: plugin-dir
-            - mountPath: /registration
-              name: registration-dir
-        - command:
-            - /bin/hcloud-csi-driver-node
-          env:
-            - name: CSI_ENDPOINT
-              value: unix:///run/csi/socket
-            - name: METRICS_ENDPOINT
-              value: 0.0.0.0:9189
-            - name: ENABLE_METRICS
-              value: "true"
-          image: hetznercloud/hcloud-csi-driver:v2.3.2
-          imagePullPolicy: Always
-          livenessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /healthz
-              port: healthz
-            initialDelaySeconds: 10
-            periodSeconds: 2
-            timeoutSeconds: 3
-          name: hcloud-csi-driver
-          ports:
-            - containerPort: 9189
-              name: metrics
-            - containerPort: 9808
-              name: healthz
-              protocol: TCP
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - mountPath: /var/lib/kubelet
-              mountPropagation: Bidirectional
-              name: kubelet-dir
-            - mountPath: /run/csi
-              name: plugin-dir
-            - mountPath: /dev
-              name: device-dir
-        - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
-          imagePullPolicy: Always
-          name: liveness-probe
-          volumeMounts:
-            - mountPath: /run/csi
-              name: plugin-dir
-      tolerations:
-        - effect: NoExecute
-          operator: Exists
-        - effect: NoSchedule
-          operator: Exists
-        - key: CriticalAddonsOnly
-          operator: Exists
-      volumes:
-        - hostPath:
-            path: /var/lib/kubelet
-            type: Directory
-          name: kubelet-dir
-        - hostPath:
-            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
-            type: DirectoryOrCreate
-          name: plugin-dir
-        - hostPath:
-            path: /var/lib/kubelet/plugins_registry/
-            type: Directory
-          name: registration-dir
-        - hostPath:
-            path: /dev
-            type: Directory
-          name: device-dir
----
+# Source: hcloud-csi/templates/core/csidriver.yaml
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
@@ -390,4 +398,4 @@ spec:
   fsGroupPolicy: File
   podInfoOnMount: true
   volumeLifecycleModes:
-    - Persistent
+  - Persistent

--- a/variables.tf
+++ b/variables.tf
@@ -116,9 +116,14 @@ variable "primary_ip_family" {
 }
 
 variable "kubernetes_version" {
-  description = "Version of Kubernetes to install (default: 1.27.1)"
+  description = "Version of Kubernetes to install (default: 1.28.3)"
   type        = string
-  default     = "1.27.1"
+  default     = "1.28.3"
+
+  validation {
+    condition     = can(regex("^1\\.([0-9]+)\\.([0-9]+)$", var.kubernetes_version))
+    error_message = "The kubernetes_version value must be a \"1.x.y\"."
+  }
 }
 
 variable "use_hcloud_network" {


### PR DESCRIPTION
- Upgrade Hetzner CCM
- Upgrade Hetzner CSI
- Default to v1.28.3 Kubernetes version
- Switch to the new DEB and RPM repositories for k8s components