### PR TITLE
feat: Add use_nftables option, bump Kubernetes and addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ and check the access by viewing the created cluster nodes:
 ```cmd
 $ kubectl get nodes --kubeconfig=kubeconfig.conf
 NAME                  STATUS   ROLES           AGE   VERSION
-k8s-control-plane-0   Ready    control-plane   31m   v1.34.1
-k8s-worker-0          Ready    <none>          31m   v1.34.1
-k8s-worker-1          Ready    <none>          31m   v1.34.1
+k8s-control-plane-0   Ready    control-plane   31m   v1.35.3
+k8s-worker-0          Ready    <none>          31m   v1.35.3
+k8s-worker-1          Ready    <none>          31m   v1.35.3
 ```
 
 ## Supported base images
@@ -80,7 +80,7 @@ The module should work on most major RPM and DEB distros. It been tested on thes
 
 - Ubuntu 24.04 (`ubuntu-24.04`)
 - Debian 13 (`debian-13`)
-- Fedora 42 (`fedora-42`)
+- Fedora 43 (`fedora-43`)
 
 Others may work as well, but have not been tested.
 
@@ -192,15 +192,13 @@ See [example](./examples/private_network.tf) for more details.
 Read these notes carefully before using this module in production.
 
 - Control plane services that use host networking, such as etcd, kubelet and api-server bind on a public IP. This is not a problem per se since these components all use mTLS for communication, but appropriate Hetzner Firewall rules can be added (make sure to allow UDP port 24601 for Wireguard node-to-node tunnels)
-- Wigglenet is a custom network plugin with a smaller community than mainstream alternatives like Cilium or Calico. It has been used successfully for several years,
-  though primarily in smaller-scale deployments. NetworkPolicy support was added in v0.5.0 and is relatively new, so don't use it as your only line of defense.
+- Wigglenet is a custom network plugin with a smaller community than mainstream alternatives like Cilium or Calico. It has been used successfully for several years, though primarily in smaller-scale deployments.
 - kubelet serving certificates are self-signed. This can be an issue for metrics-server. See [here for details and workarounds](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs).
 - Some restrictions on day-2 operations. The following are supported seamlessly, but other changes will likely require the manual steps:
    - Node replacement (see notes above for control plane nodes)
    - Vertical scaling of node (changing the server type)
    - Horizontal scaling (changing node count).
    - Changing cluster addons settings (Wigglenet firewall settings, Hetzner API token for the Hetzner CCM and CSI).
-- As kube-proxy is configured to use IPVS mode, `load-balancer.hetzner.cloud/hostname: <hostname>` must be set on all `LoadBalancer` services, otherwise healthchecks will fail and the service will not be accessible from outsie the cluster (see [this issue](https://github.com/kubernetes/kubernetes/issues/79783) for more details)
 
 In addition some caveats for dual-stack clusters in general:
 

--- a/addons.tf
+++ b/addons.tf
@@ -7,6 +7,7 @@ resource "null_resource" "install_addons" {
     wigglenet_manifest = templatefile("${path.module}/templates/wigglenet.yaml.tpl", {
       filter_pod_ingress_ipv6 = var.filter_pod_ingress_ipv6
       native_routing_ipv4     = var.use_hcloud_network
+      firewall_backend        = var.use_nftables ? "nftables" : "iptables"
     })
     ccm_manifest = templatefile("${path.module}/templates/hetzner_ccm.yaml.tpl", {
       use_hcloud_network = var.use_hcloud_network

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -65,6 +65,7 @@ resource "null_resource" "cluster_bootstrap" {
       service_cidr_ipv6      = var.service_cidr_ipv6
       primary_ip_family      = var.primary_ip_family
       kubernetes_version     = var.kubernetes_version
+      kube_proxy_mode        = var.use_nftables ? "nftables" : "iptables"
     })
     destination = "/root/cluster.yaml"
   }

--- a/examples/cloud_init.tf
+++ b/examples/cloud_init.tf
@@ -12,7 +12,7 @@ terraform {
 variable "hetzner_token" {}
 
 provider "hcloud" {
-  token = vars.hetzner_token
+  token = var.hetzner_token
 }
 
 resource "hcloud_ssh_key" "key" {
@@ -25,9 +25,9 @@ module "cluster" {
 
   name           = "k8s"
   hcloud_ssh_key = hcloud_ssh_key.key.id
-  hcloud_token   = vars.hetzner_token
+  hcloud_token   = var.hetzner_token
   location       = "hel1"
-  server_type    = "cpx31"
+  server_type    = "cpx32"
 }
 
 // After control plane is set up, additional workers can be joined
@@ -37,7 +37,7 @@ resource "hcloud_server" "instance" {
   ssh_keys    = [hcloud_ssh_key.key.id]
   image       = "ubuntu-20.04"
   location    = "hel1"
-  server_type = "cpx31"
+  server_type = "cpx32"
 
   user_data = module.cluster.join_user_data
 }

--- a/examples/ha_dns_name.tf
+++ b/examples/ha_dns_name.tf
@@ -37,7 +37,7 @@ module "cluster" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   hcloud_token   = var.hetzner_token
   location       = "nbg1"
-  server_type    = "cpx31"
+  server_type    = "cpx32"
   node_count     = 3
 
   control_plane_endpoint = "k8s.example.com"
@@ -53,7 +53,7 @@ module "workers" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   location       = "nbg1"
 
-  server_type = "cpx31"
+  server_type = "cpx32"
 }
 
 resource "aws_route53_record" "api_server_aaaa" {

--- a/examples/ha_load_balancer.tf
+++ b/examples/ha_load_balancer.tf
@@ -28,7 +28,7 @@ module "cluster" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   hcloud_token   = var.hetzner_token
   location       = "nbg1"
-  server_type    = "cpx31"
+  server_type    = "cpx32"
   node_count     = 3
 
   load_balancer_type = "lb11"
@@ -44,7 +44,7 @@ module "workers" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   location       = "nbg1"
 
-  server_type = "cpx31"
+  server_type = "cpx32"
 }
 
 output "load_balancer_ipv4" {

--- a/examples/private_network.tf
+++ b/examples/private_network.tf
@@ -12,7 +12,7 @@ terraform {
 variable "hetzner_token" {}
 
 provider "hcloud" {
-  token = vars.hetzner_token
+  token = var.hetzner_token
 }
 
 resource "hcloud_ssh_key" "key" {
@@ -25,9 +25,9 @@ module "cluster" {
 
   name           = "k8s"
   hcloud_ssh_key = hcloud_ssh_key.key.id
-  hcloud_token   = vars.hetzner_token
+  hcloud_token   = var.hetzner_token
   location       = "hel1"
-  server_type    = "cpx31"
+  server_type    = "cpx32"
 
   # The default pod_cidr_ipv4 is 10.96.0.0/16. This can be customized,
   # but it should be within the range of the private network. Also, it should
@@ -49,7 +49,7 @@ module "workers" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   location       = "hel1"
 
-  server_type = "cpx31"
+  server_type = "cpx32"
 
   use_hcloud_network = true
   hcloud_network_id  = hcloud_network.my_net.id

--- a/examples/simple.tf
+++ b/examples/simple.tf
@@ -12,7 +12,7 @@ terraform {
 variable "hetzner_token" {}
 
 provider "hcloud" {
-  token = vars.hetzner_token
+  token = var.hetzner_token
 }
 
 resource "hcloud_ssh_key" "key" {
@@ -25,9 +25,9 @@ module "cluster" {
 
   name           = "k8s"
   hcloud_ssh_key = hcloud_ssh_key.key.id
-  hcloud_token   = vars.hetzner_token
+  hcloud_token   = var.hetzner_token
   location       = "hel1"
-  server_type    = "cpx31"
+  server_type    = "cpx32"
 }
 
 module "workers" {
@@ -40,7 +40,7 @@ module "workers" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   location       = "hel1"
 
-  server_type = "cpx31"
+  server_type = "cpx32"
 }
 
 output "simple_kubeconfig" {

--- a/modules/kubernetes-node/scripts/prepare-node.sh.tpl
+++ b/modules/kubernetes-node/scripts/prepare-node.sh.tpl
@@ -20,7 +20,7 @@ install_prerequisites() {
     # Install prerequisites
     apt-get -qq update
     apt-get -qq -y upgrade
-    apt-get -qq -y install apt-transport-https ca-certificates curl gnupg lsb-release ipvsadm wireguard apparmor
+    apt-get -qq -y install apt-transport-https ca-certificates curl gnupg lsb-release ipvsadm nftables wireguard apparmor
     curl -fsSL "https://download.docker.com/linux/$os_id/gpg" | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
     curl -fsSL "https://pkgs.k8s.io/core:/stable:/v${kubernetes_minor_version}/deb/Release.key" | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/$os_id $(lsb_release -cs) stable" \
@@ -55,15 +55,15 @@ EOF
 
     if [ "$os_id" == "fedora" ]; then
       addrepo https://download.docker.com/linux/fedora/docker-ce.repo
-      dnf -qy install containerd.io ipvsadm wireguard-tools iproute-tc
+      dnf -qy install containerd.io ipvsadm nftables wireguard-tools iproute-tc
     elif [ "$(. /etc/os-release && echo "$PLATFORM_ID")" = "platform:el9" ]; then
       # Wireguard is installed by default on EL9-like systems
       addrepo https://download.docker.com/linux/centos/docker-ce.repo
-      dnf -qy install containerd.io ipvsadm wireguard-tools iproute-tc
+      dnf -qy install containerd.io ipvsadm nftables wireguard-tools iproute-tc
     else
       addrepo https://download.docker.com/linux/centos/docker-ce.repo
       dnf -qy install elrepo-release epel-release
-      dnf -qy install containerd.io ipvsadm kmod-wireguard wireguard-tools iproute-tc
+      dnf -qy install containerd.io ipvsadm nftables kmod-wireguard wireguard-tools iproute-tc
     fi
   fi
 }

--- a/modules/worker-node/variables.tf
+++ b/modules/worker-node/variables.tf
@@ -13,9 +13,9 @@ variable "hcloud_ssh_key" {
 }
 
 variable "server_type" {
-  description = "Server SKU (default: 'cpx31')"
+  description = "Server SKU (default: 'cpx32')"
   type        = string
-  default     = "cpx31"
+  default     = "cpx32"
 }
 
 variable "image" {
@@ -51,7 +51,7 @@ variable "labels" {
 variable "kubernetes_version" {
   description = "Kubernetes version"
   type        = string
-  default     = "1.34.1"
+  default     = "1.35.3"
 
   validation {
     condition     = can(regex("^1\\.([0-9]+)\\.([0-9]+)$", var.kubernetes_version))

--- a/templates/hetzner_ccm.yaml.tpl
+++ b/templates/hetzner_ccm.yaml.tpl
@@ -6,15 +6,82 @@ metadata:
   name: hcloud-cloud-controller-manager
   namespace: kube-system
 ---
+# Source: hcloud-cloud-controller-manager/templates/clusterrole.yml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "system:hcloud-cloud-controller-manager"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+---
 # Source: hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: "system:hcloud-cloud-controller-manager"
+  # The prefix ":restricted" originates from removing the cluster-admin role from HCCM.
+  # Renaming the ClusterRoleBinding makes the migration easier for users.
+  name: "system:hcloud-cloud-controller-manager:restricted"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: "system:hcloud-cloud-controller-manager"
 subjects:
   - kind: ServiceAccount
     name: hcloud-cloud-controller-manager
@@ -54,9 +121,9 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
           operator: Exists
+
         - key: "node.kubernetes.io/not-ready"
           effect: "NoExecute"
-
       containers:
         - name: hcloud-cloud-controller-manager
           args:
@@ -89,7 +156,7 @@ spec:
 %{ endif ~}
             - name: HCLOUD_INSTANCES_ADDRESS_FAMILY
               value: dualstack
-          image: docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.27.0 # x-releaser-pleaser-version
+          image: docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.30.1 # x-releaser-pleaser-version
           ports:
             - name: metrics
               containerPort: 8233
@@ -97,4 +164,4 @@ spec:
             requests:
               cpu: 100m
               memory: 50Mi
-      priorityClassName: system-cluster-critical
+      priorityClassName: "system-cluster-critical"

--- a/templates/hetzner_csi.yaml.tpl
+++ b/templates/hetzner_csi.yaml.tpl
@@ -78,6 +78,9 @@ rules:
   - apiGroups: [""]
     resources: [pods]
     verbs: [get, list, watch]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
   # node
   - apiGroups: [""]
     resources: [events]
@@ -190,7 +193,7 @@ spec:
       initContainers:
       containers:
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           imagePullPolicy: IfNotPresent
           args:
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
@@ -203,7 +206,7 @@ spec:
             limits: {}
             requests: {}
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - mountPath: /run/csi
@@ -212,9 +215,10 @@ spec:
             limits: {}
             requests: {}
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.18.0 # x-releaser-pleaser-version
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.20.0 # x-releaser-pleaser-version
           imagePullPolicy: IfNotPresent
-          command: [/bin/hcloud-csi-driver-node]
+          args:
+            - -node
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
@@ -310,57 +314,11 @@ spec:
         fsGroup: 1001
       initContainers:
       containers:
-        - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits: {}
-            requests: {}
-          args:
-            - --default-fstype=ext4
-          volumeMounts:
-          - name: socket-dir
-            mountPath: /run/csi
-
-        - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits: {}
-            requests: {}
-          args:
-            - --feature-gates=RecoverVolumeExpansionFailure=false
-          volumeMounts:
-          - name: socket-dir
-            mountPath: /run/csi
-
-        - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits: {}
-            requests: {}
-          args:
-            - --feature-gates=Topology=true
-            - --default-fstype=ext4
-          volumeMounts:
-          - name: socket-dir
-            mountPath: /run/csi
-
-        - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits: {}
-            requests: {}
-          volumeMounts:
-          - mountPath: /run/csi
-            name: socket-dir
-
         - name: hcloud-csi-driver
-          image: docker.io/hetznercloud/hcloud-csi-driver:v2.18.0 # x-releaser-pleaser-version
+          image: docker.io/hetznercloud/hcloud-csi-driver:v2.20.0 # x-releaser-pleaser-version
           imagePullPolicy: IfNotPresent
-          command: [/bin/hcloud-csi-driver-controller]
+          args:
+            - -controller
           env:
             - name: CSI_ENDPOINT
               value: unix:///run/csi/socket
@@ -399,6 +357,51 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi
+        - name: csi-attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
+          args:
+            - --default-fstype=ext4
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /run/csi
+
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /run/csi
+
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
+          args:
+            - --feature-gates=Topology=true
+            - --default-fstype=ext4
+            - --extra-create-metadata
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /run/csi
+
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+          - mountPath: /run/csi
+            name: socket-dir
 
       volumes:
         - name: socket-dir

--- a/templates/kubeadm.yaml.tpl
+++ b/templates/kubeadm.yaml.tpl
@@ -28,5 +28,5 @@ controlPlaneEndpoint: "${control_plane_endpoint}:6443"
 ---
 kind: KubeProxyConfiguration
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
-mode: ipvs
+mode: ${kube_proxy_mode}
 bindAddress: "::"

--- a/templates/wigglenet.yaml.tpl
+++ b/templates/wigglenet.yaml.tpl
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: wigglenet
       containers:
       - name: wigglenet
-        image: ghcr.io/tibordp/wigglenet:v0.5.0
+        image: ghcr.io/tibordp/wigglenet:v0.6.1
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_NAME
@@ -113,14 +113,19 @@ spec:
           # Enable NetworkPolicy enforcement
         - name: ENABLE_NETWORK_POLICY
           value: "1"
+          # Firewall backend ("nftables" or "iptables")
+        - name: FIREWALL_BACKEND
+          value: "${firewall_backend}"
         volumeMounts:
         - name: cfg
           mountPath: /etc/wigglenet
         - name: cni-cfg
           mountPath: /etc/cni/net.d
+%{ if firewall_backend == "iptables" ~}
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
+%{ endif ~}
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
@@ -142,10 +147,12 @@ spec:
       - name: cni-cfg
         hostPath:
           path: /etc/cni/net.d
+%{ if firewall_backend == "iptables" ~}
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
+%{ endif ~}
       - name: lib-modules
         hostPath:
           path: /lib/modules

--- a/test/main.tf
+++ b/test/main.tf
@@ -26,7 +26,7 @@ module "simple_cluster" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   hcloud_token   = var.hetzner_token
   location       = "hel1"
-  server_type    = "cpx21"
+  server_type    = "cpx22"
 }
 
 module "simple_worker_node" {
@@ -38,7 +38,7 @@ module "simple_worker_node" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   location       = "hel1"
 
-  server_type = "cpx21"
+  server_type = "cpx22"
 }
 
 module "ha_cluster" {
@@ -48,7 +48,7 @@ module "ha_cluster" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   hcloud_token   = var.hetzner_token
   location       = "hel1"
-  server_type    = "cpx21"
+  server_type    = "cpx22"
 
   load_balancer_type = "lb11"
 
@@ -64,7 +64,7 @@ module "ha_worker_node" {
   hcloud_ssh_key = hcloud_ssh_key.key.id
   location       = "hel1"
 
-  server_type = "cpx21"
+  server_type = "cpx22"
 }
 
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -17,7 +17,7 @@ teardown_cluster() {
 
 case "$1" in
 kubectl)
-    curl -LO https://dl.k8s.io/release/v1.34.1/bin/linux/amd64/kubectl
+    curl -LO https://dl.k8s.io/release/v1.35.3/bin/linux/amd64/kubectl
     chmod +x kubectl
     ;;
 setup)

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,9 @@ variable "hcloud_ssh_key" {
 }
 
 variable "server_type" {
-  description = "Server SKU for control plane nodes (default: 'cpx31')"
+  description = "Server SKU for control plane nodes (default: 'cpx32')"
   type        = string
-  default     = "cpx31"
+  default     = "cpx32"
 }
 
 variable "hcloud_token" {
@@ -104,6 +104,12 @@ variable "filter_pod_ingress_ipv6" {
   default     = true
 }
 
+variable "use_nftables" {
+  description = "Use the nftables backend for kube-proxy and wigglenet (default: true)"
+  type        = bool
+  default     = true
+}
+
 variable "primary_ip_family" {
   description = "(Optional) Primary IP family for Service resources in cluster (default: ipv6)"
   type        = string
@@ -116,9 +122,9 @@ variable "primary_ip_family" {
 }
 
 variable "kubernetes_version" {
-  description = "Version of Kubernetes to install (default: 1.34.1)"
+  description = "Version of Kubernetes to install (default: 1.35.3)"
   type        = string
-  default     = "1.34.1"
+  default     = "1.35.3"
 
   validation {
     condition     = can(regex("^1\\.([0-9]+)\\.([0-9]+)$", var.kubernetes_version))


### PR DESCRIPTION
- Add `use_nftables` variable (default true) controlling kube-proxy mode and wigglenet's firewall backend; defaults give nftables on both, false falls back to iptables on both. Gate wigglenet's xtables-lock mount behind iptables mode.
- Bump wigglenet to v0.6.1, Kubernetes default to v1.35.3, Hetzner CCM to v1.30.1, CSI driver to v2.20.0, sidecars updated to match.
- Install nftables userland on all distros so admins can inspect rules regardless of the active backend.
- Bump default server type from cpx31 to cpx32 across the module and all examples; bump tested Fedora image to fedora-43.
- Fix `vars.hetzner_token` typo in examples/{simple,cloud_init,private_network}.tf.
- README: drop stale ipvs/LoadBalancer hostname caveat, refresh example kubectl output to v1.35.3.